### PR TITLE
Read temp unit from device

### DIFF
--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -25,7 +25,6 @@ namespace esphome
 
       case ESP_GATTC_CONNECT_EVT:
       {
-        ESP_LOGD(TAG, "this->unplugged_probe_value_: %f", this->unplugged_probe_value_);
         ESP_LOGD(TAG, "Setting encryption");
         esp_ble_set_encryption(param->connect.remote_bda, ESP_BLE_SEC_ENCRYPT);
         break;
@@ -265,13 +264,11 @@ namespace esphome
       bool probe_unplugged = raw_temp == UNPLUGGED_PROBE_CONSTANT;
       bool publish = true;
       float temp = (float)raw_temp;
-      ESP_LOGD(TAG, "this->unplugged_probe_value_: %f", this->unplugged_probe_value_);
       if (probe_unplugged)
       {
         temp = this->unplugged_probe_value_;
         publish = send_value_when_unplugged_;
       }
-      ESP_LOGD(TAG, "Temp after unplugged logic: %f", temp);
       switch (probe)
       {
       case 1:

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -25,7 +25,7 @@ namespace esphome
 
       case ESP_GATTC_CONNECT_EVT:
       {
-        ESP_LOGD(TAG, "this->unplugged_probe_value: %f", this->unplugged_probe_value);
+        ESP_LOGD(TAG, "this->unplugged_probe_value_: %f", this->unplugged_probe_value_);
         ESP_LOGD(TAG, "Setting encryption");
         esp_ble_set_encryption(param->connect.remote_bda, ESP_BLE_SEC_ENCRYPT);
         break;
@@ -265,10 +265,10 @@ namespace esphome
       bool probe_unplugged = raw_temp == UNPLUGGED_PROBE_CONSTANT;
       bool publish = true;
       float temp = (float)raw_temp;
-      ESP_LOGD(TAG, "this->unplugged_probe_value: %f", this->unplugged_probe_value);
+      ESP_LOGD(TAG, "this->unplugged_probe_value_: %f", this->unplugged_probe_value_);
       if (probe_unplugged)
       {
-        temp = this->unplugged_probe_value;
+        temp = this->unplugged_probe_value_;
         publish = send_value_when_unplugged_;
       }
       ESP_LOGD(TAG, "Temp after unplugged logic: %f", temp);

--- a/components/igrill/igrill.h
+++ b/components/igrill/igrill.h
@@ -26,6 +26,7 @@ namespace esphome
     static const char *const IGRILLV2_TEMPERATURE_SERVICE_UUID = "A5C50000-F186-4BD6-97F2-7EBACBA0D708";
     static const char *const IGRILLV202_TEMPERATURE_SERVICE_UUID = "ADA7590F-2E6D-469E-8F7B-1822B386A5E9";
     static const char *const IGRILLV3_TEMPERATURE_SERVICE_UUID = "6E910000-58DC-41C7-943F-518B278CEA88";
+    static const char *const TEMPERATURE_UNIT_UUID = "06ef0001-2e06-4b79-9e33-fce2c42805ec";
     static const char *const PROBE1_TEMPERATURE = "06ef0002-2e06-4b79-9e33-fce2c42805ec";
     static const char *const PROBE2_TEMPERATURE = "06ef0004-2e06-4b79-9e33-fce2c42805ec";
     static const char *const PROBE3_TEMPERATURE = "06ef0006-2e06-4b79-9e33-fce2c42805ec";
@@ -40,6 +41,9 @@ namespace esphome
     static const char *const BATTERY_LEVEL_UUID = "2A19";
 
     static const uint16_t UNPLUGGED_PROBE_CONSTANT = 63536;
+    
+    static const char *const FAHRENHEIT_UNIT_STRING = "°F";
+    static const char *const CELCIUS_UNIT_STRING = "°C";
 
     class IGrill : public PollingComponent, public ble_client::BLEClientNode
     {
@@ -65,9 +69,11 @@ namespace esphome
       void get_temperature_probe_handles_(const char *service);
       uint16_t get_handle_(const char *service, const char *chr);
       void read_battery_(uint8_t *value, uint16_t value_len);
+      void read_temperature_unit_(uint8_t *value, uint16_t value_len);
       void read_propane_(uint8_t *value, uint16_t value_len);
       void read_temperature_(uint8_t *value, uint16_t value_len, int probe);
       void request_read_values_();
+      void request_temp_unit_read_();
       void request_device_challenge_read_();
       void send_authentication_challenge_();
       void loopback_device_challenge_response_(uint8_t *raw_value, uint16_t value_len);
@@ -75,6 +81,7 @@ namespace esphome
       int num_probes = 0;
       bool send_value_when_unplugged_;
       float unplugged_probe_value;
+      std::string unit_of_measurement_;
 
       sensor::Sensor *temperature_probe1_sensor_{nullptr};
       sensor::Sensor *temperature_probe2_sensor_{nullptr};
@@ -86,6 +93,7 @@ namespace esphome
       uint16_t app_challenge_handle_;
       uint16_t device_challenge_handle_;
       uint16_t device_response_handle_;
+      uint16_t temperature_unit_handle_;
       uint16_t probe1_handle_;
       uint16_t probe2_handle_;
       uint16_t probe3_handle_;

--- a/components/igrill/igrill.h
+++ b/components/igrill/igrill.h
@@ -61,7 +61,7 @@ namespace esphome
       void set_propane(sensor::Sensor *propane) { propane_level_sensor_ = propane; }
       void set_battery(sensor::Sensor *battery) { battery_level_sensor_ = battery; }
       void set_send_value_when_unplugged(bool send_value_when_unplugged) { send_value_when_unplugged_ = send_value_when_unplugged; }
-      void set_unplugged_probe_value(float unplugged_probe_value) {unplugged_probe_value = unplugged_probe_value; }
+      void set_unplugged_probe_value(float unplugged_probe_value) {unplugged_probe_value_ = unplugged_probe_value; }
 
     protected:
       void detect_and_init_igrill_model_();
@@ -80,7 +80,7 @@ namespace esphome
 
       int num_probes = 0;
       bool send_value_when_unplugged_;
-      float unplugged_probe_value;
+      float unplugged_probe_value_;
       std::string unit_of_measurement_;
 
       sensor::Sensor *temperature_probe1_sensor_{nullptr};

--- a/components/igrill/sensor.py
+++ b/components/igrill/sensor.py
@@ -40,25 +40,21 @@ CONFIG_SCHEMA = cv.All(
                 entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             ),
             cv.Optional(CONF_TEMPERATURE_PROBE1): sensor.sensor_schema(
-                unit_of_measurement=UNIT_CELSIUS,
                 accuracy_decimals=2,
                 device_class=DEVICE_CLASS_TEMPERATURE,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional(CONF_TEMPERATURE_PROBE2): sensor.sensor_schema(
-                unit_of_measurement=UNIT_CELSIUS,
                 accuracy_decimals=2,
                 device_class=DEVICE_CLASS_TEMPERATURE,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional(CONF_TEMPERATURE_PROBE3): sensor.sensor_schema(
-                unit_of_measurement=UNIT_CELSIUS,
                 accuracy_decimals=2,
                 device_class=DEVICE_CLASS_TEMPERATURE,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional(CONF_TEMPERATURE_PROBE4): sensor.sensor_schema(
-                unit_of_measurement=UNIT_CELSIUS,
                 accuracy_decimals=2,
                 device_class=DEVICE_CLASS_TEMPERATURE,
                 state_class=STATE_CLASS_MEASUREMENT,


### PR DESCRIPTION
The component now reads the temperature unit from the device and sets `unit_of_measurement` on the `sensors` accordingly.

Also fixes a bug where `unplugged_probe_value` was not initialized correctly.