### PR TITLE
Changes unit_of_measurement_ to char pointer

### DIFF
--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -265,7 +265,7 @@ namespace esphome
       {
         this->unit_of_measurement_ = CELCIUS_UNIT_STRING;
       }
-      ESP_LOGI(TAG, "Setting temperature unit based on device: %s", this->unit_of_measurement_.c_str());
+      ESP_LOGI(TAG, "Setting temperature unit based on device: %s", this->unit_of_measurement_);
 
       if (this->temperature_probe1_sensor_ != nullptr)
       {
@@ -328,7 +328,7 @@ namespace esphome
       switch (this->node_state)
       {
       case esp32_ble_tracker::ClientState::ESTABLISHED:
-        if (this->unit_of_measurement_.empty())
+        if (!this->unit_of_measurement_)
         {
           ESP_LOGD(TAG, "Requesting read of temperature unit");
           request_temp_unit_read_();

--- a/components/igrill/igrill.h
+++ b/components/igrill/igrill.h
@@ -84,7 +84,7 @@ namespace esphome
       int num_probes = 0;
       bool send_value_when_unplugged_;
       float unplugged_probe_value_;
-      std::string unit_of_measurement_;
+      const char *unit_of_measurement_{nullptr};
 
       sensor::Sensor *temperature_probe1_sensor_{nullptr};
       sensor::Sensor *temperature_probe2_sensor_{nullptr};


### PR DESCRIPTION
After updating to ESPhome 2023.5.1 Sensor::set_unit_of_measurement() changed from const std::string to const char *
https://github.com/esphome/esphome/commit/535003014b121b17fad17878979a0e63e3b3de1a