### PR TITLE
Only read configured probes

### DIFF
--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -290,7 +290,7 @@ namespace esphome
         }
         else
         {
-          ESP_LOGD(TAG, "Requesting read of all probe values");
+          ESP_LOGD(TAG, "Requesting read of all values");
           request_read_values_();
         }
         break;
@@ -352,7 +352,7 @@ namespace esphome
       // Read battery level
       if (this->battery_level_sensor_ != nullptr)
       {
-        ESP_LOGD(TAG, "Requesting read of battery level on handle (0x%x)", this->battery_level_handle_);
+        ESP_LOGV(TAG, "Requesting read of battery level on handle (0x%x)", this->battery_level_handle_);
         status = esp_ble_gattc_read_char(this->parent()->get_gattc_if(), this->parent()->get_conn_id(), this->battery_level_handle_, ESP_GATT_AUTH_REQ_NONE);
         if (status)
         {
@@ -363,7 +363,7 @@ namespace esphome
       // Read temperature probes
       for (auto & probe_handle : probe_handles_)
       {
-        ESP_LOGD(TAG, "Requesting read of temperature probe on handle (0x%x)", probe_handle);
+        ESP_LOGV(TAG, "Requesting read of temperature probe on handle (0x%x)", probe_handle);
         status = esp_ble_gattc_read_char(this->parent()->get_gattc_if(), this->parent()->get_conn_id(), probe_handle, ESP_GATT_AUTH_REQ_NONE);
         if (status)
         {
@@ -374,7 +374,7 @@ namespace esphome
       // Read propane level
       if (this->propane_level_sensor_ != nullptr)
       {
-        ESP_LOGD(TAG, "Requesting read of propane level on handle (0x%x)", this->propane_level_handle_);
+        ESP_LOGV(TAG, "Requesting read of propane level on handle (0x%x)", this->propane_level_handle_);
         status = esp_ble_gattc_read_char(this->parent()->get_gattc_if(), this->parent()->get_conn_id(), this->propane_level_handle_, ESP_GATT_AUTH_REQ_NONE);
         if (status)
         {

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -284,8 +284,8 @@ namespace esphome
     void IGrill::read_temperature_(uint8_t *raw_value, uint16_t value_len, int probe)
     {
       ESP_LOGD(TAG, "Parsing temperature from probe %d: raw_value: %p value_len: %d", probe, raw_value, value_len);
-      ESP_LOGD(TAG, "(raw_value[1] << 8): %d", (raw_value[1] << 8))
-      ESP_LOGD(TAG, "raw_value[0]: %d", raw_value[0])
+      ESP_LOGD(TAG, "(raw_value[1] << 8): %d", (raw_value[1] << 8));
+      ESP_LOGD(TAG, "raw_value[0]: %d", raw_value[0]);
       uint16_t raw_temp = (raw_value[1] << 8) | raw_value[0];
       ESP_LOGD(TAG, "Parsing temperature from probe %d: Raw_temp = %s", probe, raw_temp);
       bool probe_unplugged = raw_temp == UNPLUGGED_PROBE_CONSTANT;

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -27,7 +27,7 @@ namespace esphome
       {
         if (!is_same_address_(param->connect.remote_bda, this->parent()->get_remote_bda()))
         {
-          ESP_LOGD(TAG, "This ESP_GATTC_CONNECT_EVT is not for me. (remote_bda mismatch");
+          ESP_LOGV(TAG, "This ESP_GATTC_CONNECT_EVT is not for me. (remote_bda mismatch");
           break;
         }
         ESP_LOGD(TAG, "Setting encryption");
@@ -45,7 +45,7 @@ namespace esphome
       {
         if (param->search_cmpl.conn_id != this->parent()->get_conn_id())
         {
-          ESP_LOGD(TAG, "This ESP_GATTC_SEARCH_CMPL_EVT is not for me. (conn_id mismatch");
+          ESP_LOGV(TAG, "This ESP_GATTC_SEARCH_CMPL_EVT is not for me. (conn_id mismatch");
           break;
         }
         // Detect IGrill model and get hadles for the appropriate number of probes.
@@ -79,7 +79,7 @@ namespace esphome
       {
         if (param->write.conn_id != this->parent()->get_conn_id())
         {
-          ESP_LOGD(TAG, "This ESP_GATTC_WRITE_CHAR_EVT is not for me. (conn_id mismatch");
+          ESP_LOGV(TAG, "This ESP_GATTC_WRITE_CHAR_EVT is not for me. (conn_id mismatch");
           break;
         }
         if (param->write.status != ESP_GATT_OK)
@@ -105,7 +105,7 @@ namespace esphome
       {
         if (param->read.conn_id != this->parent()->get_conn_id())
         {
-          ESP_LOGD(TAG, "This ESP_GATTC_READ_CHAR_EVT is not for me. (conn_id mismatch");
+          ESP_LOGV(TAG, "This ESP_GATTC_READ_CHAR_EVT is not for me. (conn_id mismatch");
         }
         else if (param->read.status != ESP_GATT_OK)
         {
@@ -115,8 +115,7 @@ namespace esphome
         {
           if (value_readers_.count(param->read.handle))
           {
-            ESP_LOGD(TAG, "Read char event received for handle: 0x%x", param->read.handle);
-            ESP_LOGD(TAG, "Attempting to use read_function with address: %p",value_readers_[param->read.handle]);
+            ESP_LOGV(TAG, "Read char event received for handle: 0x%x", param->read.handle);
             (this->*value_readers_[param->read.handle])(param->read.value, param->read.value_len);
           }
           else{
@@ -208,7 +207,7 @@ namespace esphome
           uint16_t probe_handle = get_handle_(service, probes[i]);
           this->probe_handles_.push_back(probe_handle);
           this->value_readers_[probe_handle] = read_functions[i];
-          ESP_LOGD(TAG, "Probe nuber %d added with handle 0x%x", i, probe_handle);
+          ESP_LOGV(TAG, "Probe nuber %d added with handle 0x%x", i, probe_handle);
         }
         else
         {
@@ -283,8 +282,7 @@ namespace esphome
     
     void IGrill::read_temperature_(uint8_t *raw_value, uint16_t value_len, int probe)
     {
-      ESP_LOGD(TAG, "Parsing temperature from probe %d: raw_value: %p value_len: %d", probe, raw_value, value_len);
-      ESP_LOGD(TAG, "raw_temp: %d", (raw_value[1] << 8) | raw_value[0]);
+      ESP_LOGD(TAG, "Parsing temperature from probe %d: raw_temp: %f value_len: %d", probe, ((float)(raw_value[1] << 8) | raw_value[0]), value_len);
       uint16_t raw_temp = (raw_value[1] << 8) | raw_value[0];
       ESP_LOGD(TAG, "Parsing temperature from probe %d: Raw_temp = %s", probe, raw_temp);
       bool probe_unplugged = raw_temp == UNPLUGGED_PROBE_CONSTANT;

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -181,6 +181,7 @@ namespace esphome
       }
       IGrill::add_temperature_probe_handles_(service);
       this->temperature_unit_handle_ = get_handle_(service, TEMPERATURE_UNIT_UUID);
+      this->value_readers_[this->temperature_unit_handle_] = &IGrill::read_temperature_unit_;
     }
 
     bool IGrill::has_service_(const char *service)
@@ -202,9 +203,10 @@ namespace esphome
       {
         if (this->sensors_[i]) // only add handles for configured sensors
         {
-          ESP_LOGD(TAG, "Probe nuber %d added.", i);
-          this->probe_handles_.push_back(get_handle_(service, probes[i]));
-          this->value_readers_[get_handle_(service, probes[i])] = read_functions[i];
+          uint16_t probe_handle = get_handle_(service, probes[i]);
+          this->probe_handles_.push_back(probe_handle);
+          this->value_readers_[probe_handle] = read_functions[i];
+          ESP_LOGD(TAG, "Probe nuber %d added with handle 0x%x.", i, probe_handle);
         }
         else
         {

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -116,7 +116,7 @@ namespace esphome
           if (value_readers_.count(param->read.handle))
           {
             ESP_LOGD(TAG, "Read char event received for handle: 0x%x", param->read.handle);
-            ESP_LOGD(TAG, "attempting to use read_function with address: %p",value_readers_[param->read.handle]);
+            ESP_LOGD(TAG, "Attempting to use read_function with address: %p",value_readers_[param->read.handle]);
             (this->*value_readers_[param->read.handle])(param->read.value, param->read.value_len);
           }
           else{
@@ -208,7 +208,7 @@ namespace esphome
           uint16_t probe_handle = get_handle_(service, probes[i]);
           this->probe_handles_.push_back(probe_handle);
           this->value_readers_[probe_handle] = read_functions[i];
-          ESP_LOGD(TAG, "Probe nuber %d added with handle 0x%x and read_function %p.", i, probe_handle, read_functions[i]);
+          ESP_LOGD(TAG, "Probe nuber %d added with handle 0x%x", i, probe_handle);
         }
         else
         {
@@ -242,21 +242,25 @@ namespace esphome
 
     void IGrill::read_temperature1_(uint8_t *value, uint16_t value_len)
     {
+      ESP_LOGD(TAG, "Parsing temperature from probe 1");
       read_temperature_(value, value_len, 0); 
     }
 
     void IGrill::read_temperature2_(uint8_t *value, uint16_t value_len)
     {
+      ESP_LOGD(TAG, "Parsing temperature from probe 1");
       read_temperature_(value, value_len, 1);
     }
 
     void IGrill::read_temperature3_(uint8_t *value, uint16_t value_len)
     {
+      ESP_LOGD(TAG, "Parsing temperature from probe 1");
       read_temperature_(value, value_len, 2);
     }
 
     void IGrill::read_temperature4_(uint8_t *value, uint16_t value_len)
     {
+      ESP_LOGD(TAG, "Parsing temperature from probe 1");
       read_temperature_(value, value_len, 3);
     }
 

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -348,7 +348,7 @@ namespace esphome
     {
       // Read battery level
       auto status = esp_ble_gattc_read_char(this->parent()->get_gattc_if(), this->parent()->get_conn_id(), this->battery_level_handle_, ESP_GATT_AUTH_REQ_NONE);
-      ESP_LOGD(TAG, "Requested read of battery level on handle (0x%x)", this->battery_level_handle_)
+      ESP_LOGD(TAG, "Requested read of battery level on handle (0x%x)", this->battery_level_handle_);
       {
         ESP_LOGW(TAG, "Error sending read request for sensor, status=%d", status);
       }

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -242,28 +242,67 @@ namespace esphome
     void IGrill::read_temperature1_(uint8_t *value, uint16_t value_len)
     {
       uint16_t raw_temp = (value[1] << 8) | value[0];
-      ESP_LOGW(TAG, "Raw temp for probe 1: %d", raw_temp);
+      ESP_LOGD(TAG, "Parsing temperature from probe %d: Raw_temp = %s", probe, raw_temp);
+      bool probe_unplugged = raw_temp == UNPLUGGED_PROBE_CONSTANT;
+      bool publish = true;
+      float temp = (float)raw_temp;
+      if (probe_unplugged)
+      {
+        temp = this->unplugged_probe_value_;
+        publish = send_value_when_unplugged_;
+      }
+      ESP_LOGD(TAG, "Temp %f: publish: %d", temp, publish);
       return;
       IGrill::read_temperature_(value, value_len, 0); 
     }
 
     void IGrill::read_temperature2_(uint8_t *value, uint16_t value_len)
     {
-      ESP_LOGW(TAG, "Should have read temp for probe 2, but skipping");
+      uint16_t raw_temp = (value[1] << 8) | value[0];
+      ESP_LOGD(TAG, "Parsing temperature from probe %d: Raw_temp = %s", probe, raw_temp);
+      bool probe_unplugged = raw_temp == UNPLUGGED_PROBE_CONSTANT;
+      bool publish = true;
+      float temp = (float)raw_temp;
+      if (probe_unplugged)
+      {
+        temp = this->unplugged_probe_value_;
+        publish = send_value_when_unplugged_;
+      }
+      ESP_LOGD(TAG, "Temp %f: publish: %d", temp, publish);
       return;
       IGrill::read_temperature_(value, value_len, 1);
     }
 
     void IGrill::read_temperature3_(uint8_t *value, uint16_t value_len)
     {
-      ESP_LOGW(TAG, "Should have read temp for probe 3, but skipping");
+      uint16_t raw_temp = (value[1] << 8) | value[0];
+      ESP_LOGD(TAG, "Parsing temperature from probe %d: Raw_temp = %s", probe, raw_temp);
+      bool probe_unplugged = raw_temp == UNPLUGGED_PROBE_CONSTANT;
+      bool publish = true;
+      float temp = (float)raw_temp;
+      if (probe_unplugged)
+      {
+        temp = this->unplugged_probe_value_;
+        publish = send_value_when_unplugged_;
+      }
+      ESP_LOGD(TAG, "Temp %f: publish: %d", temp, publish);
       return;
       IGrill::read_temperature_(value, value_len, 2);
     }
 
     void IGrill::read_temperature4_(uint8_t *value, uint16_t value_len)
     {
-      ESP_LOGW(TAG, "Should have read temp for probe 4, but skipping");
+      uint16_t raw_temp = (value[1] << 8) | value[0];
+      ESP_LOGD(TAG, "Parsing temperature from probe %d: Raw_temp = %s", probe, raw_temp);
+      bool probe_unplugged = raw_temp == UNPLUGGED_PROBE_CONSTANT;
+      bool publish = true;
+      float temp = (float)raw_temp;
+      if (probe_unplugged)
+      {
+        temp = this->unplugged_probe_value_;
+        publish = send_value_when_unplugged_;
+      }
+      ESP_LOGD(TAG, "Temp %f: publish: %d", temp, publish);
       return;
       IGrill::read_temperature_(value, value_len, 3);
     }

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -241,21 +241,29 @@ namespace esphome
 
     void IGrill::read_temperature1_(uint8_t *value, uint16_t value_len)
     {
+      ESP_LOGW(TAG, "Should have read temp for probe 1, but skipping");
+      return;
       IGrill::read_temperature_(value, value_len, 0); 
     }
 
     void IGrill::read_temperature2_(uint8_t *value, uint16_t value_len)
     {
+      ESP_LOGW(TAG, "Should have read temp for probe 2, but skipping");
+      return;
       IGrill::read_temperature_(value, value_len, 1);
     }
 
     void IGrill::read_temperature3_(uint8_t *value, uint16_t value_len)
     {
+      ESP_LOGW(TAG, "Should have read temp for probe 3, but skipping");
+      return;
       IGrill::read_temperature_(value, value_len, 2);
     }
 
     void IGrill::read_temperature4_(uint8_t *value, uint16_t value_len)
     {
+      ESP_LOGW(TAG, "Should have read temp for probe 4, but skipping");
+      return;
       IGrill::read_temperature_(value, value_len, 3);
     }
 
@@ -282,7 +290,6 @@ namespace esphome
     
     void IGrill::read_temperature_(uint8_t *raw_value, uint16_t value_len, int probe)
     {
-      ESP_LOGD(TAG, "Parsing temp for probe %d", probe + 1); 
       uint16_t raw_temp = (raw_value[1] << 8) | raw_value[0];
       ESP_LOGD(TAG, "Parsing temperature from probe %d: Raw_temp = %s", probe, raw_temp);
       bool probe_unplugged = raw_temp == UNPLUGGED_PROBE_CONSTANT;
@@ -295,7 +302,6 @@ namespace esphome
       }
       if (publish)
       {
-        sleep(1);
         this->sensors_[probe]->publish_state(temp);
       }
     }

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -242,15 +242,7 @@ namespace esphome
     void IGrill::read_temperature1_(uint8_t *value, uint16_t value_len)
     {
       ESP_LOGW(TAG, "Should have read temp for probe 1, but skipping");
-      ESP_LOGD(TAG, "just logging");
-      ESP_LOGD(TAG, "just logging");
-      ESP_LOGD(TAG, "just logging");
-      ESP_LOGD(TAG, "just logging");
-      ESP_LOGD(TAG, "just logging");
-      ESP_LOGD(TAG, "just logging");
-      ESP_LOGD(TAG, "just logging");
-      ESP_LOGD(TAG, "just logging");
-      ESP_LOGD(TAG, "just logging");
+      ESP_LOGD(TAG, "just logging one of the values: %d", UNPLUGGED_PROBE_CONSTANT);
       return;
       IGrill::read_temperature_(value, value_len, 0); 
     }

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -327,51 +327,52 @@ namespace esphome
 
     void IGrill::request_device_challenge_read_()
     {
-      ESP_LOGD(TAG, "Requesting read of encrypted device response from device");
+      ESP_LOGD(TAG, "Requesting read of encrypted device response from device on handle (0x%x)", this->device_challenge_handle_);
       auto status = esp_ble_gattc_read_char(this->parent()->get_gattc_if(), this->parent()->get_conn_id(), this->device_challenge_handle_, ESP_GATT_AUTH_REQ_NONE);
       if (status)
       {
-        ESP_LOGW(TAG, "Error sending read request for device_challenge, status=%d", status);
+        ESP_LOGW(TAG, "Error sending read request for device_challenge, status=%d, handle=0x%x", status, this->device_challenge_handle_);
       }
     }
 
     void IGrill::request_temp_unit_read_()
     {
+      ESP_LOGD(TAG, "Requesting read of temperature unit on handle (0x%x)", this->battery_level_handle_);
       auto status = esp_ble_gattc_read_char(this->parent()->get_gattc_if(), this->parent()->get_conn_id(), this->temperature_unit_handle_, ESP_GATT_AUTH_REQ_NONE);
       if (status)
       {
-        ESP_LOGW(TAG, "Error sending read request for temperature unit, status=%d", status);
+        ESP_LOGW(TAG, "Error sending read request for temperature unit, status=%d, handle=0x%x", status, this->temperature_unit_handle_);
       }
     }
 
     void IGrill::request_read_values_()
     {
       // Read battery level
+      ESP_LOGD(TAG, "Requesting read of battery level on handle (0x%x)", this->battery_level_handle_);
       auto status = esp_ble_gattc_read_char(this->parent()->get_gattc_if(), this->parent()->get_conn_id(), this->battery_level_handle_, ESP_GATT_AUTH_REQ_NONE);
-      ESP_LOGD(TAG, "Requested read of battery level on handle (0x%x)", this->battery_level_handle_);
       {
-        ESP_LOGW(TAG, "Error sending read request for sensor, status=%d", status);
+        ESP_LOGW(TAG, "Error sending read request for sensor, status=%d, handle=0x%x", status, this->battery_level_handle_);
       }
 
       // Read temperature probes
       for (auto & probe_handle : probe_handles_)
       {
+        ESP_LOGD(TAG, "Requesting read of temperature probe on handle (0x%x)", probe_handle);
         status = esp_ble_gattc_read_char(this->parent()->get_gattc_if(), this->parent()->get_conn_id(), probe_handle, ESP_GATT_AUTH_REQ_NONE);
-        ESP_LOGD(TAG, "Requested read of temperature probe on handle (0x%x)", probe_handle);
         if (status)
         {
-          ESP_LOGW(TAG, "Error sending read request for sensor, status=%d", status);
+          ESP_LOGW(TAG, "Error sending read request for sensor, status=%d, handle=0x%x", status, probe_handle);
         }
       }
 
       // Read propane level
       if (this->propane_level_sensor_ != nullptr)
       {
+        ESP_LOGD(TAG, "Requesting read of propane level on handle (0x%x)", this->propane_level_handle_);
         status = esp_ble_gattc_read_char(this->parent()->get_gattc_if(), this->parent()->get_conn_id(), this->propane_level_handle_, ESP_GATT_AUTH_REQ_NONE);
-        ESP_LOGD(TAG, "Requested read of propane level on handle (0x%x)", this->propane_level_handle_);
         if (status)
         {
-          ESP_LOGW(TAG, "Error sending read request for sensor, status=%d", status);
+          ESP_LOGW(TAG, "Error sending read request for sensor, status=%d, handle=0x%x", status, this->propane_level_handle_);
         }
       }
     }

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -357,7 +357,7 @@ namespace esphome
       for (auto & probe_handle : probe_handles_)
       {
         status = esp_ble_gattc_read_char(this->parent()->get_gattc_if(), this->parent()->get_conn_id(), probe_handle, ESP_GATT_AUTH_REQ_NONE);
-        ESP_LOGD(TAG, "Requested read of temperature probe on handle (0x%x)", this->probe_handle);
+        ESP_LOGD(TAG, "Requested read of temperature probe on handle (0x%x)", probe_handle);
         if (status)
         {
           ESP_LOGW(TAG, "Error sending read request for sensor, status=%d", status);

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -242,6 +242,7 @@ namespace esphome
     void IGrill::read_temperature1_(uint8_t *value, uint16_t value_len)
     {
       ESP_LOGW(TAG, "Should have read temp for probe 1, but skipping");
+      ESP_LOGD(TAG, "DEBUG: free heap: %u", ESP.getFreeHeap());
       uint16_t raw_temp = (value[1] << 8) | value[0];
       bool probe_unplugged = raw_temp == UNPLUGGED_PROBE_CONSTANT;
       bool publish = true;

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -242,7 +242,8 @@ namespace esphome
     void IGrill::read_temperature1_(uint8_t *value, uint16_t value_len)
     {
       ESP_LOGW(TAG, "Should have read temp for probe 1, but skipping");
-      ESP_LOGD(TAG, "just logging one of the values: %d", (raw_value[1] << 8) | raw_value[0]);
+      uint16_t raw_temp = (value[1] << 8) | value[0];
+      ESP_LOGD(TAG, "just logging one of the values: %d", raw_temp);
       ESP_LOGD(TAG, "just logging one of the values: %d", UNPLUGGED_PROBE_CONSTANT);
       return;
       IGrill::read_temperature_(value, value_len, 0); 

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -263,7 +263,7 @@ namespace esphome
     void IGrill::read_temperature_(uint8_t *raw_value, uint16_t value_len, int probe)
     {
       uint16_t raw_temp = (raw_value[1] << 8) | raw_value[0];
-      ESP_LOGD(TAG, "Parsing temperature from probe %d", probe);
+      ESP_LOGV(TAG, "Parsing temperature from probe %d", probe);
       bool probe_unplugged = raw_temp == UNPLUGGED_PROBE_CONSTANT;
       bool publish = true;
       float temp = (float)raw_temp;

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -295,6 +295,7 @@ namespace esphome
       }
       if (publish)
       {
+        sleep(1);
         this->sensors_[probe]->publish_state(temp);
       }
     }

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -190,7 +190,7 @@ namespace esphome
       auto *srv = this->parent()->get_service(esp32_ble_tracker::ESPBTUUID::from_raw(service));
       if (srv == nullptr)
       {
-        ESP_LOGD(TAG, "No service found at service %s", service);
+        ESP_LOGV(TAG, "No service found at service %s", service);
         return false;
       }
       return true;

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -211,7 +211,7 @@ namespace esphome
         }
         else
         {
-          ESP_LOGD(TAG, "No sensor configured for probe nuber %d. Skipping", i);
+          ESP_LOGD(TAG, "No sensor configured for probe nuber %d. Skipping", i+1);
         }
       }
     }

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -295,7 +295,7 @@ namespace esphome
       }
       if (publish)
       {
-        sensors_[probe]->publish_state(temp);
+        this->sensors_[probe]->publish_state(temp);
       }
     }
 

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -266,22 +266,12 @@ namespace esphome
         this->unit_of_measurement_ = CELCIUS_UNIT_STRING;
       }
       ESP_LOGI(TAG, "Setting temperature unit based on device: %s", this->unit_of_measurement_);
-
-      if (this->temperature_probe1_sensor_ != nullptr)
+      for (auto & element : this->sensors_)
       {
-        temperature_probe1_sensor_->set_unit_of_measurement(this->unit_of_measurement_);
-      }
-      if (this->temperature_probe2_sensor_ != nullptr)
-      {
-        temperature_probe2_sensor_->set_unit_of_measurement(this->unit_of_measurement_);
-      }
-      if (this->temperature_probe3_sensor_ != nullptr)
-      {
-        temperature_probe3_sensor_->set_unit_of_measurement(this->unit_of_measurement_);
-      }
-      if (this->temperature_probe4_sensor_ != nullptr)
-      {
-        temperature_probe4_sensor_->set_unit_of_measurement(this->unit_of_measurement_);
+        if (element)
+        {
+          element->set_unit_of_measurement(this->unit_of_measurement_);
+        }
       }
       request_read_values_();
     }
@@ -299,27 +289,7 @@ namespace esphome
       }
       if (publish)
       {
-        switch (probe)
-        {
-        case 1:
-          this->temperature_probe1_sensor_->publish_state(temp);
-          break;
-
-        case 2:
-          this->temperature_probe2_sensor_->publish_state(temp);
-          break;
-
-        case 3:
-          this->temperature_probe3_sensor_->publish_state(temp);
-          break;
-
-        case 4:
-          this->temperature_probe4_sensor_->publish_state(temp);
-          break;
-
-        default:
-          break;
-        }
+        sensors_[probe]->publish_state(temp);
       }
     }
 
@@ -437,10 +407,13 @@ namespace esphome
 
     void IGrill::dump_config()
     {
-      LOG_SENSOR("  ", "Temperature", this->temperature_probe1_sensor_);
-      LOG_SENSOR("  ", "Temperature", this->temperature_probe2_sensor_);
-      LOG_SENSOR("  ", "Temperature", this->temperature_probe3_sensor_);
-      LOG_SENSOR("  ", "Temperature", this->temperature_probe4_sensor_);
+      for (auto & element : this->sensors_)
+      {
+        if (element)
+        {
+          LOG_SENSOR("  ", "Temperature", element);
+        }
+      }
       LOG_SENSOR("  ", "Battery Level", this->battery_level_sensor_);
       LOG_SENSOR("  ", "Propane Level", this->propane_level_sensor_);
     }

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -242,15 +242,7 @@ namespace esphome
 
     void IGrill::read_temperature1_(uint8_t *value, uint16_t value_len)
     {
-      ESP_LOGW(TAG, "Should have read temp for probe 1, but skipping");
       ESP_LOGD(TAG, "DEBUG: free heap: %u", ESP.getFreeHeap());
-      uint16_t raw_temp = (value[1] << 8) | value[0];
-      bool probe_unplugged = raw_temp == UNPLUGGED_PROBE_CONSTANT;
-      bool publish = true;
-      float temp = (float)raw_temp;
-      ESP_LOGD(TAG, "just logging one of the values: %f", temp);
-      ESP_LOGD(TAG, "just logging one of the values: %d", probe_unplugged);
-      return;
       IGrill::read_temperature_(value, value_len, 0); 
     }
 

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -243,8 +243,11 @@ namespace esphome
     {
       ESP_LOGW(TAG, "Should have read temp for probe 1, but skipping");
       uint16_t raw_temp = (value[1] << 8) | value[0];
-      ESP_LOGD(TAG, "just logging one of the values: %d", raw_temp);
-      ESP_LOGD(TAG, "just logging one of the values: %d", UNPLUGGED_PROBE_CONSTANT);
+      bool probe_unplugged = raw_temp == UNPLUGGED_PROBE_CONSTANT;
+      bool publish = true;
+      float temp = (float)raw_temp;
+      ESP_LOGD(TAG, "just logging one of the values: %f", temp);
+      ESP_LOGD(TAG, "just logging one of the values: %d", probe_unplugged);
       return;
       IGrill::read_temperature_(value, value_len, 0); 
     }

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -241,7 +241,8 @@ namespace esphome
 
     void IGrill::read_temperature1_(uint8_t *value, uint16_t value_len)
     {
-      ESP_LOGW(TAG, "Should have read temp for probe 1, but skipping");
+      uint16_t raw_temp = (value[1] << 8) | value[0];
+      ESP_LOGW(TAG, "Raw temp for probe 1: %d", raw_temp);
       return;
       IGrill::read_temperature_(value, value_len, 0); 
     }

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -241,17 +241,7 @@ namespace esphome
 
     void IGrill::read_temperature1_(uint8_t *value, uint16_t value_len)
     {
-      uint16_t raw_temp = (value[1] << 8) | value[0];
-      ESP_LOGD(TAG, "Parsing temperature from probe %d: Raw_temp = %s", 1, raw_temp);
-      // bool probe_unplugged = raw_temp == UNPLUGGED_PROBE_CONSTANT;
-      // bool publish = true;
-      // float temp = (float)raw_temp;
-      // if (probe_unplugged)
-      // {
-      //  temp = this->unplugged_probe_value_;
-      //  publish = this->send_value_when_unplugged_;
-      // }
-      //ESP_LOGD(TAG, "Temp %f: publish: %d", temp, publish);
+      ESP_LOGW(TAG, "Should have read temp for probe 2, but skipping");
       return;
       IGrill::read_temperature_(value, value_len, 0); 
     }

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -53,20 +53,20 @@ namespace esphome
 
         // Get handle for battery level
         this->battery_level_handle_ = get_handle_(BATTERY_SERVICE_UUID, BATTERY_LEVEL_UUID);
-        this->value_readers_[this->battery_level_handle_] = &read_battery_;
+        this->value_readers_[this->battery_level_handle_] = &IGrill::read_battery_;
 
         // Get handle for propane level, if configured
         if (this->propane_level_sensor_ != nullptr)
         {
           this->propane_level_handle_ = get_handle_(PROPANE_LEVEL_SERVICE_UUID, PROPANE_LEVEL);
-          this->value_readers_[this->propane_level_handle_] = &read_propane_;
+          this->value_readers_[this->propane_level_handle_] = &IGrill::read_propane_;
         }
 
         // Get handles for authentication
         this->app_challenge_handle_ = get_handle_(AUTHENTICATION_SERVICE_UUID, APP_CHALLENGE_UUID);
         this->device_response_handle_ = get_handle_(AUTHENTICATION_SERVICE_UUID, DEVICE_RESPONSE_UUID);
         this->device_challenge_handle_ = get_handle_(AUTHENTICATION_SERVICE_UUID, DEVICE_CHALLENGE_UUID);
-        this->value_readers_[this->device_challenge_handle_] = &loopback_device_challenge_response_;
+        this->value_readers_[this->device_challenge_handle_] = &IGrill::loopback_device_challenge_response_;
 
         ESP_LOGD(TAG, "Starting autheintication process");
         send_authentication_challenge_();
@@ -197,7 +197,7 @@ namespace esphome
     void IGrill::add_temperature_probe_handles_(const char *service)
     {
       std::vector<const char *> probes = {PROBE1_TEMPERATURE, PROBE2_TEMPERATURE, PROBE3_TEMPERATURE, PROBE4_TEMPERATURE};
-      std::vector<void (esphome::igrill::IGrill::*)(uint8_t *, uint16_t)> read_functions = {&read_temperature1_, &read_temperature2_, &read_temperature3_, &read_temperature4_};
+      std::vector<void (esphome::igrill::IGrill::*)(uint8_t *, uint16_t)> read_functions = {&IGrill::read_temperature1_, &IGrill::read_temperature2_, &IGrill::read_temperature3_, &IGrill::read_temperature4_};
       for (int i = 0; i < this->num_probes; i++)
       {
         if (this->sensors_[i]) // only add handles for configured sensors

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -328,7 +328,7 @@ namespace esphome
 
     void IGrill::request_device_challenge_read_()
     {
-      ESP_LOGD(TAG, "Requesting read of encrypted device response from device on handle (0x%x)", this->device_challenge_handle_);
+      ESP_LOGV(TAG, "Requesting read of encrypted device response from device on handle (0x%x)", this->device_challenge_handle_);
       auto status = esp_ble_gattc_read_char(this->parent()->get_gattc_if(), this->parent()->get_conn_id(), this->device_challenge_handle_, ESP_GATT_AUTH_REQ_NONE);
       if (status)
       {
@@ -338,7 +338,7 @@ namespace esphome
 
     void IGrill::request_temp_unit_read_()
     {
-      ESP_LOGD(TAG, "Requesting read of temperature unit on handle (0x%x)", this->temperature_unit_handle_);
+      ESP_LOGV(TAG, "Requesting read of temperature unit on handle (0x%x)", this->temperature_unit_handle_);
       auto status = esp_ble_gattc_read_char(this->parent()->get_gattc_if(), this->parent()->get_conn_id(), this->temperature_unit_handle_, ESP_GATT_AUTH_REQ_NONE);
       if (status)
       {

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -338,7 +338,7 @@ namespace esphome
 
     void IGrill::request_temp_unit_read_()
     {
-      ESP_LOGD(TAG, "Requesting read of temperature unit on handle (0x%x)", this->battery_level_handle_);
+      ESP_LOGD(TAG, "Requesting read of temperature unit on handle (0x%x)", this->temperature_unit_handle_);
       auto status = esp_ble_gattc_read_char(this->parent()->get_gattc_if(), this->parent()->get_conn_id(), this->temperature_unit_handle_, ESP_GATT_AUTH_REQ_NONE);
       if (status)
       {

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -242,25 +242,21 @@ namespace esphome
 
     void IGrill::read_temperature1_(uint8_t *value, uint16_t value_len)
     {
-      ESP_LOGD(TAG, "Parsing temperature from probe 1");
       IGrill::read_temperature_(value, value_len, 0); 
     }
 
     void IGrill::read_temperature2_(uint8_t *value, uint16_t value_len)
     {
-      ESP_LOGD(TAG, "Parsing temperature from probe 2");
       IGrill::read_temperature_(value, value_len, 1);
     }
 
     void IGrill::read_temperature3_(uint8_t *value, uint16_t value_len)
     {
-      ESP_LOGD(TAG, "Parsing temperature from probe 3");
       IGrill::read_temperature_(value, value_len, 2);
     }
 
     void IGrill::read_temperature4_(uint8_t *value, uint16_t value_len)
     {
-      ESP_LOGD(TAG, "Parsing temperature from probe 4");
       IGrill::read_temperature_(value, value_len, 3);
     }
 
@@ -287,6 +283,7 @@ namespace esphome
     
     void IGrill::read_temperature_(uint8_t *raw_value, uint16_t value_len, int probe)
     {
+      ESP_LOGD(TAG, "Parsing temperature from probe %d", probe);
       uint16_t raw_temp = (raw_value[1] << 8) | raw_value[0];
       ESP_LOGD(TAG, "Parsing temperature from probe %d: Raw_temp = %s", probe, raw_temp);
       bool probe_unplugged = raw_temp == UNPLUGGED_PROBE_CONSTANT;

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -283,7 +283,7 @@ namespace esphome
     
     void IGrill::read_temperature_(uint8_t *raw_value, uint16_t value_len, int probe)
     {
-      ESP_LOGD(TAG, "Parsing temperature from probe %d", probe);
+      ESP_LOGD(TAG, "Parsing temperature from probe %d: raw_value: %p value_len: %d", probe, raw_value, value_len);
       uint16_t raw_temp = (raw_value[1] << 8) | raw_value[0];
       ESP_LOGD(TAG, "Parsing temperature from probe %d: Raw_temp = %s", probe, raw_temp);
       bool probe_unplugged = raw_temp == UNPLUGGED_PROBE_CONSTANT;

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -122,22 +122,22 @@ namespace esphome
         }
         else if (param->read.handle == this->probe1_handle_)
         {
-          read_temperature_(param->read.value, param->read.value_len, 1);
+          read_temperature1_(param->read.value, param->read.value_len);
           break;
         }
         else if (param->read.handle == this->probe2_handle_)
         {
-          read_temperature_(param->read.value, param->read.value_len, 2);
+          read_temperature2_(param->read.value, param->read.value_len);
           break;
         }
         else if (param->read.handle == this->probe3_handle_)
         {
-          read_temperature_(param->read.value, param->read.value_len, 3);
+          read_temperature3_(param->read.value, param->read.value_len);
           break;
         }
         else if (param->read.handle == this->probe4_handle_)
         {
-          read_temperature_(param->read.value, param->read.value_len, 4);
+          read_temperature4_(param->read.value, param->read.value_len);
           break;
         }
         else if (param->read.handle == this->temperature_unit_handle_)

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -282,7 +282,7 @@ namespace esphome
     
     void IGrill::read_temperature_(uint8_t *raw_value, uint16_t value_len, int probe)
     {
-      ESP_LOGD(TAG, "Parsing temperature from probe %d: raw_temp: %f value_len: %d", probe, ((float)(raw_value[1] << 8) | raw_value[0]), value_len);
+      ESP_LOGD(TAG, "Parsing temp for probe %d", probe + 1); 
       uint16_t raw_temp = (raw_value[1] << 8) | raw_value[0];
       ESP_LOGD(TAG, "Parsing temperature from probe %d: Raw_temp = %s", probe, raw_temp);
       bool probe_unplugged = raw_temp == UNPLUGGED_PROBE_CONSTANT;

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -371,6 +371,7 @@ namespace esphome
       // Read battery level
       ESP_LOGD(TAG, "Requesting read of battery level on handle (0x%x)", this->battery_level_handle_);
       auto status = esp_ble_gattc_read_char(this->parent()->get_gattc_if(), this->parent()->get_conn_id(), this->battery_level_handle_, ESP_GATT_AUTH_REQ_NONE);
+      if (status)
       {
         ESP_LOGW(TAG, "Error sending read request for sensor, status=%d, handle=0x%x", status, this->battery_level_handle_);
       }

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -243,25 +243,25 @@ namespace esphome
     void IGrill::read_temperature1_(uint8_t *value, uint16_t value_len)
     {
       ESP_LOGD(TAG, "Parsing temperature from probe 1");
-      read_temperature_(value, value_len, 0); 
+      IGrill::read_temperature_(value, value_len, 0); 
     }
 
     void IGrill::read_temperature2_(uint8_t *value, uint16_t value_len)
     {
       ESP_LOGD(TAG, "Parsing temperature from probe 2");
-      read_temperature_(value, value_len, 1);
+      IGrill::read_temperature_(value, value_len, 1);
     }
 
     void IGrill::read_temperature3_(uint8_t *value, uint16_t value_len)
     {
       ESP_LOGD(TAG, "Parsing temperature from probe 3");
-      read_temperature_(value, value_len, 2);
+      IGrill::read_temperature_(value, value_len, 2);
     }
 
     void IGrill::read_temperature4_(uint8_t *value, uint16_t value_len)
     {
       ESP_LOGD(TAG, "Parsing temperature from probe 4");
-      read_temperature_(value, value_len, 3);
+      IGrill::read_temperature_(value, value_len, 3);
     }
 
     void IGrill::read_temperature_unit_(uint8_t *raw_value, uint16_t value_len)

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -242,6 +242,7 @@ namespace esphome
     void IGrill::read_temperature1_(uint8_t *value, uint16_t value_len)
     {
       ESP_LOGW(TAG, "Should have read temp for probe 1, but skipping");
+      ESP_LOGD(TAG, "just logging one of the values: %d", (raw_value[1] << 8) | raw_value[0]);
       ESP_LOGD(TAG, "just logging one of the values: %d", UNPLUGGED_PROBE_CONSTANT);
       return;
       IGrill::read_temperature_(value, value_len, 0); 

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -241,7 +241,8 @@ namespace esphome
 
     void IGrill::read_temperature1_(uint8_t *value, uint16_t value_len)
     {
-      ESP_LOGW(TAG, "Should have read temp for probe 2, but skipping");
+      uint16_t raw_temp = (value[1] << 8) | value[0];
+      ESP_LOGD(TAG, "Parsing temperature from probe %d: Raw_temp = %s", 1, raw_temp);
       return;
       IGrill::read_temperature_(value, value_len, 0); 
     }

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -248,19 +248,19 @@ namespace esphome
 
     void IGrill::read_temperature2_(uint8_t *value, uint16_t value_len)
     {
-      ESP_LOGD(TAG, "Parsing temperature from probe 1");
+      ESP_LOGD(TAG, "Parsing temperature from probe 2");
       read_temperature_(value, value_len, 1);
     }
 
     void IGrill::read_temperature3_(uint8_t *value, uint16_t value_len)
     {
-      ESP_LOGD(TAG, "Parsing temperature from probe 1");
+      ESP_LOGD(TAG, "Parsing temperature from probe 3");
       read_temperature_(value, value_len, 2);
     }
 
     void IGrill::read_temperature4_(uint8_t *value, uint16_t value_len)
     {
-      ESP_LOGD(TAG, "Parsing temperature from probe 1");
+      ESP_LOGD(TAG, "Parsing temperature from probe 4");
       read_temperature_(value, value_len, 3);
     }
 

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -243,15 +243,15 @@ namespace esphome
     {
       uint16_t raw_temp = (value[1] << 8) | value[0];
       ESP_LOGD(TAG, "Parsing temperature from probe %d: Raw_temp = %s", 1, raw_temp);
-      bool probe_unplugged = raw_temp == UNPLUGGED_PROBE_CONSTANT;
-      bool publish = true;
-      float temp = (float)raw_temp;
-      if (probe_unplugged)
-      {
-        temp = this->unplugged_probe_value_;
-        publish = this->send_value_when_unplugged_;
-      }
-      ESP_LOGD(TAG, "Temp %f: publish: %d", temp, publish);
+      // bool probe_unplugged = raw_temp == UNPLUGGED_PROBE_CONSTANT;
+      // bool publish = true;
+      // float temp = (float)raw_temp;
+      // if (probe_unplugged)
+      // {
+      //  temp = this->unplugged_probe_value_;
+      //  publish = this->send_value_when_unplugged_;
+      // }
+      //ESP_LOGD(TAG, "Temp %f: publish: %d", temp, publish);
       return;
       IGrill::read_temperature_(value, value_len, 0); 
     }

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -116,6 +116,7 @@ namespace esphome
           if (value_readers_.count(param->read.handle))
           {
             ESP_LOGD(TAG, "Read char event received for handle: 0x%x", param->read.handle);
+            ESP_LOGD(TAG, "attempting to use read_function with address: %p",value_readers_[param->read.handle]);
             (this->*value_readers_[param->read.handle])(param->read.value, param->read.value_len);
           }
           else{

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -284,8 +284,7 @@ namespace esphome
     void IGrill::read_temperature_(uint8_t *raw_value, uint16_t value_len, int probe)
     {
       ESP_LOGD(TAG, "Parsing temperature from probe %d: raw_value: %p value_len: %d", probe, raw_value, value_len);
-      ESP_LOGD(TAG, "(raw_value[1] << 8): %d", (raw_value[1] << 8));
-      ESP_LOGD(TAG, "raw_value[0]: %d", raw_value[0]);
+      ESP_LOGD(TAG, "raw_temp: %d", (raw_value[1] << 8) | raw_value[0]);
       uint16_t raw_temp = (raw_value[1] << 8) | raw_value[0];
       ESP_LOGD(TAG, "Parsing temperature from probe %d: Raw_temp = %s", probe, raw_temp);
       bool probe_unplugged = raw_temp == UNPLUGGED_PROBE_CONSTANT;

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -270,11 +270,11 @@ namespace esphome
         this->unit_of_measurement_ = CELCIUS_UNIT_STRING;
       }
       ESP_LOGI(TAG, "Setting temperature unit based on device: %s", this->unit_of_measurement_);
-      for (auto & element : this->sensors_)
+      for (auto & sensor : this->sensors_)
       {
-        if (element)
+        if (sensor)
         {
-          element->set_unit_of_measurement(this->unit_of_measurement_);
+          sensor->set_unit_of_measurement(this->unit_of_measurement_);
         }
       }
       request_read_values_();

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -1,4 +1,5 @@
 #include "igrill.h"
+#include <Esp.h>
 
 #ifdef USE_ESP32
 

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -241,6 +241,7 @@ namespace esphome
 
     void IGrill::read_temperature1_(uint8_t *value, uint16_t value_len)
     {
+      uint16_t probe = 1;
       uint16_t raw_temp = (value[1] << 8) | value[0];
       ESP_LOGD(TAG, "Parsing temperature from probe %d: Raw_temp = %s", probe, raw_temp);
       bool probe_unplugged = raw_temp == UNPLUGGED_PROBE_CONSTANT;
@@ -258,6 +259,7 @@ namespace esphome
 
     void IGrill::read_temperature2_(uint8_t *value, uint16_t value_len)
     {
+      uint16_t probe = 2;
       uint16_t raw_temp = (value[1] << 8) | value[0];
       ESP_LOGD(TAG, "Parsing temperature from probe %d: Raw_temp = %s", probe, raw_temp);
       bool probe_unplugged = raw_temp == UNPLUGGED_PROBE_CONSTANT;
@@ -275,6 +277,7 @@ namespace esphome
 
     void IGrill::read_temperature3_(uint8_t *value, uint16_t value_len)
     {
+      uint16_t probe = 3;
       uint16_t raw_temp = (value[1] << 8) | value[0];
       ESP_LOGD(TAG, "Parsing temperature from probe %d: Raw_temp = %s", probe, raw_temp);
       bool probe_unplugged = raw_temp == UNPLUGGED_PROBE_CONSTANT;
@@ -292,6 +295,7 @@ namespace esphome
 
     void IGrill::read_temperature4_(uint8_t *value, uint16_t value_len)
     {
+      uint16_t probe = 4;
       uint16_t raw_temp = (value[1] << 8) | value[0];
       ESP_LOGD(TAG, "Parsing temperature from probe %d: Raw_temp = %s", probe, raw_temp);
       bool probe_unplugged = raw_temp == UNPLUGGED_PROBE_CONSTANT;

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -407,8 +407,14 @@ namespace esphome
           LOG_SENSOR("  ", "Temperature", element);
         }
       }
-      LOG_SENSOR("  ", "Battery Level", this->battery_level_sensor_);
-      LOG_SENSOR("  ", "Propane Level", this->propane_level_sensor_);
+      if (this->battery_level_sensor_ != nullptr)
+      {
+        LOG_SENSOR("  ", "Battery Level", this->battery_level_sensor_);
+      }
+      if (this->propane_level_sensor_ != nullptr)
+      {
+        LOG_SENSOR("  ", "Propane Level", this->propane_level_sensor_);
+      }
     }
 
     IGrill::IGrill()

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -115,10 +115,11 @@ namespace esphome
         {
           if (value_readers_.count(param->read.handle))
           {
+            ESP_LOGD(TAG, "Read char event received for handle: 0x%x", param->read.handle);
             (this->*value_readers_[param->read.handle])(param->read.value, param->read.value_len);
           }
           else{
-            ESP_LOGD(TAG, "No read function defined for handle. (0x%x)", param->read.handle);
+            ESP_LOGD(TAG, "No read function defined for handle: 0x%x", param->read.handle);
           }
         }
         break;

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -262,6 +262,7 @@ namespace esphome
     void IGrill::read_temperature_(uint8_t *raw_value, uint16_t value_len, int probe)
     {
       uint16_t raw_temp = (raw_value[1] << 8) | raw_value[0];
+      ESP_LOGD(TAG, "Parsing temperature from probe %d: Raw_temp = %s", probe, raw_temp);
       bool probe_unplugged = raw_temp == UNPLUGGED_PROBE_CONSTANT;
       bool publish = true;
       float temp = (float)raw_temp;
@@ -347,7 +348,7 @@ namespace esphome
     {
       // Read battery level
       auto status = esp_ble_gattc_read_char(this->parent()->get_gattc_if(), this->parent()->get_conn_id(), this->battery_level_handle_, ESP_GATT_AUTH_REQ_NONE);
-      if (status)
+      ESP_LOGD(TAG, "Requested read of battery level on handle (0x%x)", this->battery_level_handle_)
       {
         ESP_LOGW(TAG, "Error sending read request for sensor, status=%d", status);
       }
@@ -356,6 +357,7 @@ namespace esphome
       for (auto & probe_handle : probe_handles_)
       {
         status = esp_ble_gattc_read_char(this->parent()->get_gattc_if(), this->parent()->get_conn_id(), probe_handle, ESP_GATT_AUTH_REQ_NONE);
+        ESP_LOGD(TAG, "Requested read of temperature probe on handle (0x%x)", this->probe_handle);
         if (status)
         {
           ESP_LOGW(TAG, "Error sending read request for sensor, status=%d", status);
@@ -366,6 +368,7 @@ namespace esphome
       if (this->propane_level_sensor_ != nullptr)
       {
         status = esp_ble_gattc_read_char(this->parent()->get_gattc_if(), this->parent()->get_conn_id(), this->propane_level_handle_, ESP_GATT_AUTH_REQ_NONE);
+        ESP_LOGD(TAG, "Requested read of propane level on handle (0x%x)", this->propane_level_handle_);
         if (status)
         {
           ESP_LOGW(TAG, "Error sending read request for sensor, status=%d", status);

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -207,7 +207,7 @@ namespace esphome
           uint16_t probe_handle = get_handle_(service, probes[i]);
           this->probe_handles_.push_back(probe_handle);
           this->value_readers_[probe_handle] = read_functions[i];
-          ESP_LOGD(TAG, "Probe nuber %d added with handle 0x%x.", i, probe_handle);
+          ESP_LOGD(TAG, "Probe nuber %d added with handle 0x%x and read_function %p.", i, probe_handle, read_functions[i]);
         }
         else
         {

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -239,6 +239,26 @@ namespace esphome
       this->propane_level_sensor_->publish_state(((float)*raw_value * 25));
     }
 
+    void IGrill::read_temperature1_(uint8_t *value, uint16_t value_len)
+    {
+      read_temperature_(value, value_len, 0); 
+    }
+
+    void IGrill::read_temperature2_(uint8_t *value, uint16_t value_len)
+    {
+      read_temperature_(value, value_len, 1);
+    }
+
+    void IGrill::read_temperature3_(uint8_t *value, uint16_t value_len)
+    {
+      read_temperature_(value, value_len, 2);
+    }
+
+    void IGrill::read_temperature4_(uint8_t *value, uint16_t value_len)
+    {
+      read_temperature_(value, value_len, 3);
+    }
+
     void IGrill::read_temperature_unit_(uint8_t *raw_value, uint16_t value_len)
     {
       if (raw_value[0] == 0)
@@ -259,7 +279,7 @@ namespace esphome
       }
       request_read_values_();
     }
-
+    
     void IGrill::read_temperature_(uint8_t *raw_value, uint16_t value_len, int probe)
     {
       uint16_t raw_temp = (raw_value[1] << 8) | raw_value[0];

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -284,6 +284,8 @@ namespace esphome
     void IGrill::read_temperature_(uint8_t *raw_value, uint16_t value_len, int probe)
     {
       ESP_LOGD(TAG, "Parsing temperature from probe %d: raw_value: %p value_len: %d", probe, raw_value, value_len);
+      ESP_LOGD(TAG, "(raw_value[1] << 8): %d", (raw_value[1] << 8))
+      ESP_LOGD(TAG, "raw_value[0]: %d", raw_value[0])
       uint16_t raw_temp = (raw_value[1] << 8) | raw_value[0];
       ESP_LOGD(TAG, "Parsing temperature from probe %d: Raw_temp = %s", probe, raw_temp);
       bool probe_unplugged = raw_temp == UNPLUGGED_PROBE_CONSTANT;

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -249,7 +249,7 @@ namespace esphome
       if (probe_unplugged)
       {
         temp = this->unplugged_probe_value_;
-        publish = send_value_when_unplugged_;
+        publish = this->send_value_when_unplugged_;
       }
       ESP_LOGD(TAG, "Temp %f: publish: %d", temp, publish);
       return;

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -241,8 +241,16 @@ namespace esphome
 
     void IGrill::read_temperature1_(uint8_t *value, uint16_t value_len)
     {
-      uint16_t raw_temp = (value[1] << 8) | value[0];
-      ESP_LOGD(TAG, "Parsing temperature from probe %d: Raw_temp = %s", 1, raw_temp);
+      ESP_LOGW(TAG, "Should have read temp for probe 1, but skipping");
+      ESP_LOGD(TAG, "just logging");
+      ESP_LOGD(TAG, "just logging");
+      ESP_LOGD(TAG, "just logging");
+      ESP_LOGD(TAG, "just logging");
+      ESP_LOGD(TAG, "just logging");
+      ESP_LOGD(TAG, "just logging");
+      ESP_LOGD(TAG, "just logging");
+      ESP_LOGD(TAG, "just logging");
+      ESP_LOGD(TAG, "just logging");
       return;
       IGrill::read_temperature_(value, value_len, 0); 
     }

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -241,9 +241,8 @@ namespace esphome
 
     void IGrill::read_temperature1_(uint8_t *value, uint16_t value_len)
     {
-      uint16_t probe = 1;
       uint16_t raw_temp = (value[1] << 8) | value[0];
-      ESP_LOGD(TAG, "Parsing temperature from probe %d: Raw_temp = %s", probe, raw_temp);
+      ESP_LOGD(TAG, "Parsing temperature from probe %d: Raw_temp = %s", 1, raw_temp);
       bool probe_unplugged = raw_temp == UNPLUGGED_PROBE_CONSTANT;
       bool publish = true;
       float temp = (float)raw_temp;
@@ -259,54 +258,21 @@ namespace esphome
 
     void IGrill::read_temperature2_(uint8_t *value, uint16_t value_len)
     {
-      uint16_t probe = 2;
-      uint16_t raw_temp = (value[1] << 8) | value[0];
-      ESP_LOGD(TAG, "Parsing temperature from probe %d: Raw_temp = %s", probe, raw_temp);
-      bool probe_unplugged = raw_temp == UNPLUGGED_PROBE_CONSTANT;
-      bool publish = true;
-      float temp = (float)raw_temp;
-      if (probe_unplugged)
-      {
-        temp = this->unplugged_probe_value_;
-        publish = send_value_when_unplugged_;
-      }
-      ESP_LOGD(TAG, "Temp %f: publish: %d", temp, publish);
+      ESP_LOGW(TAG, "Should have read temp for probe 2, but skipping");
       return;
       IGrill::read_temperature_(value, value_len, 1);
     }
 
     void IGrill::read_temperature3_(uint8_t *value, uint16_t value_len)
     {
-      uint16_t probe = 3;
-      uint16_t raw_temp = (value[1] << 8) | value[0];
-      ESP_LOGD(TAG, "Parsing temperature from probe %d: Raw_temp = %s", probe, raw_temp);
-      bool probe_unplugged = raw_temp == UNPLUGGED_PROBE_CONSTANT;
-      bool publish = true;
-      float temp = (float)raw_temp;
-      if (probe_unplugged)
-      {
-        temp = this->unplugged_probe_value_;
-        publish = send_value_when_unplugged_;
-      }
-      ESP_LOGD(TAG, "Temp %f: publish: %d", temp, publish);
+      ESP_LOGW(TAG, "Should have read temp for probe 3, but skipping");
       return;
       IGrill::read_temperature_(value, value_len, 2);
     }
 
     void IGrill::read_temperature4_(uint8_t *value, uint16_t value_len)
     {
-      uint16_t probe = 4;
-      uint16_t raw_temp = (value[1] << 8) | value[0];
-      ESP_LOGD(TAG, "Parsing temperature from probe %d: Raw_temp = %s", probe, raw_temp);
-      bool probe_unplugged = raw_temp == UNPLUGGED_PROBE_CONSTANT;
-      bool publish = true;
-      float temp = (float)raw_temp;
-      if (probe_unplugged)
-      {
-        temp = this->unplugged_probe_value_;
-        publish = send_value_when_unplugged_;
-      }
-      ESP_LOGD(TAG, "Temp %f: publish: %d", temp, publish);
+      ESP_LOGW(TAG, "Should have read temp for probe 4, but skipping");
       return;
       IGrill::read_temperature_(value, value_len, 3);
     }

--- a/components/igrill/igrill.h
+++ b/components/igrill/igrill.h
@@ -57,7 +57,7 @@ namespace esphome
       void update() override;
 
       void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if, esp_ble_gattc_cb_param_t *param) override;
-      void set_temperature_probe(sensor::Sensor *temperature, int probe_num) { sensors_[probe_num] = temperature; }
+      void set_temperature_probe(sensor::Sensor *temperature, int probe_num) { sensors_[probe_num-1] = temperature; }
       void set_propane(sensor::Sensor *propane) { propane_level_sensor_ = propane; }
       void set_battery(sensor::Sensor *battery) { battery_level_sensor_ = battery; }
       void set_send_value_when_unplugged(bool send_value_when_unplugged) { ESP_LOGE("igrill", "send_value_when_unplugged: %d", send_value_when_unplugged); send_value_when_unplugged_ = send_value_when_unplugged; }

--- a/components/igrill/igrill.h
+++ b/components/igrill/igrill.h
@@ -71,6 +71,10 @@ namespace esphome
       void read_battery_(uint8_t *value, uint16_t value_len);
       void read_temperature_unit_(uint8_t *value, uint16_t value_len);
       void read_propane_(uint8_t *value, uint16_t value_len);
+      void read_temperature1_(uint8_t *value, uint16_t value_len) {read_temperature_(value, value_len, 1);}
+      void read_temperature2_(uint8_t *value, uint16_t value_len) {read_temperature_(value, value_len, 2);}
+      void read_temperature3_(uint8_t *value, uint16_t value_len) {read_temperature_(value, value_len, 3);}
+      void read_temperature4_(uint8_t *value, uint16_t value_len) {read_temperature_(value, value_len, 4);}
       void read_temperature_(uint8_t *value, uint16_t value_len, int probe);
       void request_read_values_();
       void request_temp_unit_read_();

--- a/components/igrill/igrill.h
+++ b/components/igrill/igrill.h
@@ -72,10 +72,10 @@ namespace esphome
       void read_battery_(uint8_t *value, uint16_t value_len);
       void read_temperature_unit_(uint8_t *value, uint16_t value_len);
       void read_propane_(uint8_t *value, uint16_t value_len);
-      void read_temperature1_(uint8_t *value, uint16_t value_len) {read_temperature_(value, value_len, 1);}
-      void read_temperature2_(uint8_t *value, uint16_t value_len) {read_temperature_(value, value_len, 2);}
-      void read_temperature3_(uint8_t *value, uint16_t value_len) {read_temperature_(value, value_len, 3);}
-      void read_temperature4_(uint8_t *value, uint16_t value_len) {read_temperature_(value, value_len, 4);}
+      void read_temperature1_(uint8_t *value, uint16_t value_len) {read_temperature_(value, value_len, 0);}
+      void read_temperature2_(uint8_t *value, uint16_t value_len) {read_temperature_(value, value_len, 1);}
+      void read_temperature3_(uint8_t *value, uint16_t value_len) {read_temperature_(value, value_len, 2);}
+      void read_temperature4_(uint8_t *value, uint16_t value_len) {read_temperature_(value, value_len, 3);}
       void read_temperature_(uint8_t *value, uint16_t value_len, int probe);
       void request_read_values_();
       void request_temp_unit_read_();

--- a/components/igrill/igrill.h
+++ b/components/igrill/igrill.h
@@ -72,10 +72,10 @@ namespace esphome
       void read_battery_(uint8_t *value, uint16_t value_len);
       void read_temperature_unit_(uint8_t *value, uint16_t value_len);
       void read_propane_(uint8_t *value, uint16_t value_len);
-      void read_temperature1_(uint8_t *value, uint16_t value_len);
-      void read_temperature2_(uint8_t *value, uint16_t value_len);
-      void read_temperature3_(uint8_t *value, uint16_t value_len);
-      void read_temperature4_(uint8_t *value, uint16_t value_len);
+      void read_temperature1_(uint8_t *value, uint16_t value_len){ read_temperature_(value, value_len, 0); }
+      void read_temperature2_(uint8_t *value, uint16_t value_len){ read_temperature_(value, value_len, 1); }
+      void read_temperature3_(uint8_t *value, uint16_t value_len){ read_temperature_(value, value_len, 2); }
+      void read_temperature4_(uint8_t *value, uint16_t value_len){ read_temperature_(value, value_len, 3); }
       void read_temperature_(uint8_t *value, uint16_t value_len, int probe);
       void request_read_values_();
       void request_temp_unit_read_();
@@ -87,11 +87,7 @@ namespace esphome
       bool send_value_when_unplugged_;
       float unplugged_probe_value_;
       const char *unit_of_measurement_{nullptr};
-
-      sensor::Sensor *temperature_probe1_sensor_{nullptr};
-      sensor::Sensor *temperature_probe2_sensor_{nullptr};
-      sensor::Sensor *temperature_probe3_sensor_{nullptr};
-      sensor::Sensor *temperature_probe4_sensor_{nullptr};
+      
       std::vector<sensor::Sensor *> sensors_ = {nullptr, nullptr, nullptr, nullptr};
       sensor::Sensor *battery_level_sensor_{nullptr};
       sensor::Sensor *propane_level_sensor_{nullptr};

--- a/components/igrill/igrill.h
+++ b/components/igrill/igrill.h
@@ -72,10 +72,10 @@ namespace esphome
       void read_battery_(uint8_t *value, uint16_t value_len);
       void read_temperature_unit_(uint8_t *value, uint16_t value_len);
       void read_propane_(uint8_t *value, uint16_t value_len);
-      void read_temperature1_(uint8_t *value, uint16_t value_len) {read_temperature_(value, value_len, 0);}
-      void read_temperature2_(uint8_t *value, uint16_t value_len) {read_temperature_(value, value_len, 1);}
-      void read_temperature3_(uint8_t *value, uint16_t value_len) {read_temperature_(value, value_len, 2);}
-      void read_temperature4_(uint8_t *value, uint16_t value_len) {read_temperature_(value, value_len, 3);}
+      void read_temperature1_(uint8_t *value, uint16_t value_len);
+      void read_temperature2_(uint8_t *value, uint16_t value_len);
+      void read_temperature3_(uint8_t *value, uint16_t value_len);
+      void read_temperature4_(uint8_t *value, uint16_t value_len);
       void read_temperature_(uint8_t *value, uint16_t value_len, int probe);
       void request_read_values_();
       void request_temp_unit_read_();

--- a/components/igrill/igrill.h
+++ b/components/igrill/igrill.h
@@ -4,6 +4,7 @@
 #include <esp_gattc_api.h>
 #include <algorithm>
 #include <iterator>
+#include <map>
 #include <vector>
 #include "esphome/components/ble_client/ble_client.h"
 #include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
@@ -66,7 +67,7 @@ namespace esphome
       void detect_and_init_igrill_model_();
       bool has_service_(const char *service);
       bool is_same_address_(uint8_t *a, uint8_t *b);
-      void get_temperature_probe_handles_(const char *service);
+      void add_temperature_probe_handles_(const char *service);
       uint16_t get_handle_(const char *service, const char *chr);
       void read_battery_(uint8_t *value, uint16_t value_len);
       void read_temperature_unit_(uint8_t *value, uint16_t value_len);
@@ -96,16 +97,13 @@ namespace esphome
       sensor::Sensor *propane_level_sensor_{nullptr};
 
       uint16_t app_challenge_handle_;
+      uint16_t battery_level_handle_;
       uint16_t device_challenge_handle_;
       uint16_t device_response_handle_;
-      uint16_t temperature_unit_handle_;
-      uint16_t probe1_handle_;
-      uint16_t probe2_handle_;
-      uint16_t probe3_handle_;
-      uint16_t probe4_handle_;
+      std::vector<uint16_t> probe_handles_;
       uint16_t propane_level_handle_;
-      std::vector<uint16_t *> handles = {&probe1_handle_, &probe2_handle_, &probe3_handle_, &probe4_handle_};
-      uint16_t battery_level_handle_;
+      std::map<uint16_t, void (esphome::igrill::IGrill::*)(uint8_t *, uint16_t)> value_readers_;
+      uint16_t temperature_unit_handle_;
     };
 
   } // namespace igrill

--- a/components/igrill/igrill.h
+++ b/components/igrill/igrill.h
@@ -56,10 +56,7 @@ namespace esphome
       void update() override;
 
       void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if, esp_ble_gattc_cb_param_t *param) override;
-      void set_temperature_probe1(sensor::Sensor *temperature) { temperature_probe1_sensor_ = temperature; }
-      void set_temperature_probe2(sensor::Sensor *temperature) { temperature_probe2_sensor_ = temperature; }
-      void set_temperature_probe3(sensor::Sensor *temperature) { temperature_probe3_sensor_ = temperature; }
-      void set_temperature_probe4(sensor::Sensor *temperature) { temperature_probe4_sensor_ = temperature; }
+      void set_temperature_probe(sensor::Sensor *temperature, int probe_num) { sensors_[probe_num] = temperature; }
       void set_propane(sensor::Sensor *propane) { propane_level_sensor_ = propane; }
       void set_battery(sensor::Sensor *battery) { battery_level_sensor_ = battery; }
       void set_send_value_when_unplugged(bool send_value_when_unplugged) { ESP_LOGE("igrill", "send_value_when_unplugged: %d", send_value_when_unplugged); send_value_when_unplugged_ = send_value_when_unplugged; }
@@ -90,6 +87,7 @@ namespace esphome
       sensor::Sensor *temperature_probe2_sensor_{nullptr};
       sensor::Sensor *temperature_probe3_sensor_{nullptr};
       sensor::Sensor *temperature_probe4_sensor_{nullptr};
+      std::vector<sensor::Sensor *> sensors_ = {nullptr, nullptr, nullptr, nullptr};
       sensor::Sensor *battery_level_sensor_{nullptr};
       sensor::Sensor *propane_level_sensor_{nullptr};
 

--- a/components/igrill/sensor.py
+++ b/components/igrill/sensor.py
@@ -84,16 +84,16 @@ async def to_code(config):
         cg.add(var.set_battery(sens))
     if CONF_TEMPERATURE_PROBE1 in config:
         sens = await sensor.new_sensor(config[CONF_TEMPERATURE_PROBE1])
-        cg.add(var.set_temperature_probe1(sens))
+        cg.add(var.set_temperature_probe(sens, 1))
     if CONF_TEMPERATURE_PROBE2 in config:
         sens = await sensor.new_sensor(config[CONF_TEMPERATURE_PROBE2])
-        cg.add(var.set_temperature_probe2(sens))
+        cg.add(var.set_temperature_probe(sens, 2))
     if CONF_TEMPERATURE_PROBE3 in config:
         sens = await sensor.new_sensor(config[CONF_TEMPERATURE_PROBE3])
-        cg.add(var.set_temperature_probe3(sens))
+        cg.add(var.set_temperature_probe(sens, 3))
     if CONF_TEMPERATURE_PROBE4 in config:
         sens = await sensor.new_sensor(config[CONF_TEMPERATURE_PROBE4])
-        cg.add(var.set_temperature_probe4(sens))
+        cg.add(var.set_temperature_probe(sens, 4))
     if CONF_PROPANE_LEVEL in config:
         sens = await sensor.new_sensor(config[CONF_PROPANE_LEVEL])
         cg.add(var.set_propane(sens))


### PR DESCRIPTION
Rewrites the logic to only request reads for configured probes.

Also tunes a lot of debug logging