### PR TITLE
Updates for ESPHome 2026.3.0

### DIFF
--- a/components/igrill/__init__.py
+++ b/components/igrill/__init__.py
@@ -1,0 +1,1 @@
+CODEOWNERS = ["@bendikwa"]

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -48,7 +48,7 @@ namespace esphome
           ESP_LOGV(TAG, "This ESP_GATTC_SEARCH_CMPL_EVT is not for me. (conn_id mismatch");
           break;
         }
-        // Detect IGrill model and get hadles for the appropriate number of probes.
+        // Detect IGrill model and get handles for the appropriate number of probes.
         IGrill::detect_and_init_igrill_model_();
 
         // Get handle for battery level
@@ -68,7 +68,7 @@ namespace esphome
         this->device_challenge_handle_ = get_handle_(AUTHENTICATION_SERVICE_UUID, DEVICE_CHALLENGE_UUID);
         this->value_readers_[this->device_challenge_handle_] = &IGrill::loopback_device_challenge_response_;
 
-        ESP_LOGD(TAG, "Starting autheintication process");
+        ESP_LOGD(TAG, "Starting authentication process");
         send_authentication_challenge_();
 
         this->node_state = esp32_ble_tracker::ClientState::ESTABLISHED;
@@ -118,7 +118,8 @@ namespace esphome
             ESP_LOGV(TAG, "Read char event received for handle: 0x%x", param->read.handle);
             (this->*value_readers_[param->read.handle])(param->read.value, param->read.value_len);
           }
-          else{
+          else
+          {
             ESP_LOGD(TAG, "No read function defined for handle: 0x%x", param->read.handle);
           }
         }
@@ -162,6 +163,12 @@ namespace esphome
         ESP_LOGI(TAG, "Detected model: IGrill V3");
         num_probes = 4;
         service = IGRILLV3_TEMPERATURE_SERVICE_UUID;
+      }
+      else if (has_service_(IDEVICES_KITCHEN_TEMPERATURE_SERVICE_UUID))
+      {
+        ESP_LOGI(TAG, "Detected model: iDevices Kitchen");
+        num_probes = 2;
+        service = IDEVICES_KITCHEN_TEMPERATURE_SERVICE_UUID;
       }
       else if (has_service_(PULSE_1000_TEMPERATURE_SERVICE_UUID))
       {
@@ -207,11 +214,11 @@ namespace esphome
           uint16_t probe_handle = get_handle_(service, probes[i]);
           this->probe_handles_.push_back(probe_handle);
           this->value_readers_[probe_handle] = read_functions[i];
-          ESP_LOGV(TAG, "Probe nuber %d added with handle 0x%x", i, probe_handle);
+          ESP_LOGV(TAG, "Probe number %d added with handle 0x%x", i, probe_handle);
         }
         else
         {
-          ESP_LOGD(TAG, "No sensor configured for probe nuber %d. Skipping", i+1);
+          ESP_LOGD(TAG, "No sensor configured for probe number %d. Skipping", i+1);
         }
       }
       if (service == PULSE_1000_TEMPERATURE_SERVICE_UUID || service == PULSE_2000_TEMPERATURE_SERVICE_UUID)
@@ -238,41 +245,43 @@ namespace esphome
 
     void IGrill::read_battery_(uint8_t *raw_value, uint16_t value_len)
     {
-
       this->battery_level_sensor_->publish_state((float)*raw_value);
     }
 
     void IGrill::read_propane_(uint8_t *raw_value, uint16_t value_len)
     {
-
       this->propane_level_sensor_->publish_state(((float)*raw_value * 25));
     }
 
     void IGrill::read_pulse_element_(uint8_t *raw_value, uint16_t value_len)
     {
-      if (this->pulse_heating_actual1_){
+      if (this->pulse_heating_actual1_)
+      {
         std::string actual1;
         actual1.assign(reinterpret_cast<char*>(raw_value)+1, 3);
-        ESP_LOGV(TAG, "Parsed actual1 form pulse element data %s", actual1);
+        ESP_LOGV(TAG, "Parsed actual1 from pulse element data %s", actual1.c_str());
         this->pulse_heating_actual1_->publish_state(stoi(actual1));
       }
-      if (this->pulse_heating_actual2_){
+      if (this->pulse_heating_actual2_)
+      {
         std::string actual2;
         actual2.assign(reinterpret_cast<char*>(raw_value)+5, 3);
-        ESP_LOGV(TAG, "Parsed actual2 form pulse element data %s", actual2);
+        ESP_LOGV(TAG, "Parsed actual2 from pulse element data %s", actual2.c_str());
         this->pulse_heating_actual2_->publish_state(stoi(actual2));
       }
-      if (this->pulse_heating_setpoint1_){
-        std::string setpoint1_;
-        setpoint1_.assign(reinterpret_cast<char*>(raw_value)+9, 3);
-        ESP_LOGV(TAG, "Parsed setpoint1 form pulse element data %s", setpoint1_);
-        this->pulse_heating_setpoint1_->publish_state(stoi(setpoint1_));
+      if (this->pulse_heating_setpoint1_)
+      {
+        std::string setpoint1;
+        setpoint1.assign(reinterpret_cast<char*>(raw_value)+9, 3);
+        ESP_LOGV(TAG, "Parsed setpoint1 from pulse element data %s", setpoint1.c_str());
+        this->pulse_heating_setpoint1_->publish_state(stoi(setpoint1));
       }
-      if (this->pulse_heating_setpoint2_){
-        std::string setpoint2_;
-        setpoint2_.assign(reinterpret_cast<char*>(raw_value)+13, 3);
-        ESP_LOGV(TAG, "Parsed setpoint2 form pulse element data %s", setpoint2_);
-        this->pulse_heating_setpoint2_->publish_state(stoi(setpoint2_));
+      if (this->pulse_heating_setpoint2_)
+      {
+        std::string setpoint2;
+        setpoint2.assign(reinterpret_cast<char*>(raw_value)+13, 3);
+        ESP_LOGV(TAG, "Parsed setpoint2 from pulse element data %s", setpoint2.c_str());
+        this->pulse_heating_setpoint2_->publish_state(stoi(setpoint2));
       }
     }
 
@@ -286,17 +295,14 @@ namespace esphome
       {
         this->unit_of_measurement_ = CELCIUS_UNIT_STRING;
       }
-      ESP_LOGI(TAG, "Setting temperature unit based on device: %s", this->unit_of_measurement_);
-      for (auto & sensor : this->sensors_)
-      {
-        if (sensor)
-        {
-          sensor->set_unit_of_measurement(this->unit_of_measurement_);
-        }
-      }
+      // ESPHome 2026.x removed Sensor::set_unit_of_measurement() from the public API.
+      // Unit of measurement must now be declared at compile time in the sensor schema / YAML.
+      // The device-reported unit is logged here for reference only.
+      // If your iGrill is set to °F, add `unit_of_measurement: "°F"` to each probe in YAML.
+      ESP_LOGI(TAG, "Device reports temperature unit: %s (unit set at compile time via YAML, not at runtime)", this->unit_of_measurement_);
       request_read_values_();
     }
-    
+
     void IGrill::read_temperature_(uint8_t *raw_value, uint16_t value_len, int probe)
     {
       uint16_t raw_temp = (raw_value[1] << 8) | raw_value[0];
@@ -341,10 +347,8 @@ namespace esphome
     void IGrill::send_authentication_challenge_()
     {
       uint8_t zero_payload[16] = {};
-      ;
       ESP_LOGD(TAG, "Sending app challenge with all '0's");
       auto status = esp_ble_gattc_write_char(this->parent()->get_gattc_if(), this->parent()->get_conn_id(), app_challenge_handle_, sizeof(zero_payload), zero_payload, ESP_GATT_WRITE_TYPE_RSP, ESP_GATT_AUTH_REQ_NONE);
-
       if (status)
       {
         ESP_LOGW(TAG, "Error writing challenge to app challenge characteristic, status=%d", status);
@@ -353,10 +357,8 @@ namespace esphome
 
     void IGrill::loopback_device_challenge_response_(uint8_t *raw_value, uint16_t value_len)
     {
-
       ESP_LOGD(TAG, "Sending encrypted device response back to device.");
       auto status = esp_ble_gattc_write_char(this->parent()->get_gattc_if(), this->parent()->get_conn_id(), device_response_handle_, value_len, raw_value, ESP_GATT_WRITE_TYPE_RSP, ESP_GATT_AUTH_REQ_NONE);
-
       if (status)
       {
         ESP_LOGW(TAG, "Error writing challenge response to device response characteristic, status=%d", status);
@@ -386,6 +388,7 @@ namespace esphome
     void IGrill::request_read_values_()
     {
       esp_err_t status = ESP_OK;
+
       // Read battery level
       if (this->battery_level_sensor_ != nullptr)
       {
@@ -398,7 +401,7 @@ namespace esphome
       }
 
       // Read temperature probes
-      for (auto & probe_handle : probe_handles_)
+      for (auto &probe_handle : probe_handles_)
       {
         ESP_LOGV(TAG, "Requesting read of temperature probe on handle (0x%x)", probe_handle);
         status = esp_ble_gattc_read_char(this->parent()->get_gattc_if(), this->parent()->get_conn_id(), probe_handle, ESP_GATT_AUTH_REQ_NONE);
@@ -442,13 +445,12 @@ namespace esphome
           return false;
         }
       }
-
       return true;
     }
 
     void IGrill::dump_config()
     {
-      for (auto & element : this->sensors_)
+      for (auto &element : this->sensors_)
       {
         if (element)
         {

--- a/components/igrill/igrill.h
+++ b/components/igrill/igrill.h
@@ -24,6 +24,7 @@ namespace esphome
     static const char *const DEVICE_RESPONSE_UUID = "64AC0004-4A4B-4B58-9F37-94D3C52FFDF7";
 
     static const char *const IGRILL_MINI_TEMPERATURE_SERVICE_UUID = "63C70000-4A82-4261-95FF-92CF32477861";
+    static const char *const IDEVICES_KITCHEN_TEMPERATURE_SERVICE_UUID = "19450000-9B05-40BB-80D8-7C85840AEC34";
     static const char *const IGRILL_MINIV2_TEMPERATURE_SERVICE_UUID = "9d610c43-ae1d-41a9-9b09-3c7ecd5c6035";
     static const char *const IGRILLV2_TEMPERATURE_SERVICE_UUID = "A5C50000-F186-4BD6-97F2-7EBACBA0D708";
     static const char *const IGRILLV202_TEMPERATURE_SERVICE_UUID = "ADA7590F-2E6D-469E-8F7B-1822B386A5E9";
@@ -37,7 +38,7 @@ namespace esphome
     static const char *const PROBE3_TEMPERATURE = "06ef0006-2e06-4b79-9e33-fce2c42805ec";
     static const char *const PROBE4_TEMPERATURE = "06ef0008-2e06-4b79-9e33-fce2c42805ec";
     static const char *const PULSE_ELEMENT_UUID = "6c91000a-58dc-41c7-943f-518b278ceaaa";
-    
+
     static const char *const PROPANE_LEVEL_SERVICE_UUID = "F5D40000-3548-4C22-9947-F3673FCE3CD9";
     static const char *const PROPANE_LEVEL = "f5d40001-3548-4c22-9947-f3673fce3cd9";
 
@@ -45,7 +46,7 @@ namespace esphome
     static const char *const BATTERY_LEVEL_UUID = "2A19";
 
     static const uint16_t UNPLUGGED_PROBE_CONSTANT = 63536;
-    
+
     static const char *const FAHRENHEIT_UNIT_STRING = "°F";
     static const char *const CELCIUS_UNIT_STRING = "°C";
 
@@ -65,8 +66,9 @@ namespace esphome
       void set_pulse_setpoint2(sensor::Sensor *pulse_setpoint) { pulse_heating_setpoint2_ = pulse_setpoint; }
       void set_propane(sensor::Sensor *propane) { propane_level_sensor_ = propane; }
       void set_battery(sensor::Sensor *battery) { battery_level_sensor_ = battery; }
-      void set_send_value_when_unplugged(bool send_value_when_unplugged) { ESP_LOGE("igrill", "send_value_when_unplugged: %d", send_value_when_unplugged); send_value_when_unplugged_ = send_value_when_unplugged; }
-      void set_unplugged_probe_value(float unplugged_probe_value) {unplugged_probe_value_ = unplugged_probe_value; }
+      // Removed stray ESP_LOGE debug call that was present in upstream v1.2
+      void set_send_value_when_unplugged(bool send_value_when_unplugged) { send_value_when_unplugged_ = send_value_when_unplugged; }
+      void set_unplugged_probe_value(float unplugged_probe_value) { unplugged_probe_value_ = unplugged_probe_value; }
 
     protected:
       void detect_and_init_igrill_model_();
@@ -93,7 +95,7 @@ namespace esphome
       bool send_value_when_unplugged_;
       float unplugged_probe_value_;
       const char *unit_of_measurement_{nullptr};
-      
+
       std::vector<sensor::Sensor *> sensors_ = {nullptr, nullptr, nullptr, nullptr};
       sensor::Sensor *battery_level_sensor_{nullptr};
       sensor::Sensor *propane_level_sensor_{nullptr};

--- a/components/igrill/sensor.py
+++ b/components/igrill/sensor.py
@@ -31,6 +31,17 @@ CONF_PULSE_ACTUAL2 = "pulse_heating_actual2"
 CONF_PULSE_SETPOINT1 = "pulse_heating_setpoint1"
 CONF_PULSE_SETPOINT2 = "pulse_heating_setpoint2"
 
+# ESPHome 2026.x removed Sensor::set_unit_of_measurement() from the runtime API.
+# Unit must now be set at compile time via the schema. We default to UNIT_CELSIUS
+# to match the iGrill device default. Override with `unit_of_measurement: "°F"`
+# in your YAML if your device is configured for Fahrenheit.
+_TEMPERATURE_PROBE_SCHEMA = sensor.sensor_schema(
+    unit_of_measurement=UNIT_CELSIUS,
+    accuracy_decimals=2,
+    device_class=DEVICE_CLASS_TEMPERATURE,
+    state_class=STATE_CLASS_MEASUREMENT,
+)
+
 CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
@@ -42,46 +53,14 @@ CONFIG_SCHEMA = cv.All(
                 state_class=STATE_CLASS_MEASUREMENT,
                 entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             ),
-            cv.Optional(CONF_TEMPERATURE_PROBE1): sensor.sensor_schema(
-                accuracy_decimals=2,
-                device_class=DEVICE_CLASS_TEMPERATURE,
-                state_class=STATE_CLASS_MEASUREMENT,
-            ),
-            cv.Optional(CONF_TEMPERATURE_PROBE2): sensor.sensor_schema(
-                accuracy_decimals=2,
-                device_class=DEVICE_CLASS_TEMPERATURE,
-                state_class=STATE_CLASS_MEASUREMENT,
-            ),
-            cv.Optional(CONF_TEMPERATURE_PROBE3): sensor.sensor_schema(
-                accuracy_decimals=2,
-                device_class=DEVICE_CLASS_TEMPERATURE,
-                state_class=STATE_CLASS_MEASUREMENT,
-            ),
-            cv.Optional(CONF_TEMPERATURE_PROBE4): sensor.sensor_schema(
-                accuracy_decimals=2,
-                device_class=DEVICE_CLASS_TEMPERATURE,
-                state_class=STATE_CLASS_MEASUREMENT,
-            ),
-            cv.Optional(CONF_PULSE_ACTUAL1): sensor.sensor_schema(
-                accuracy_decimals=2,
-                device_class=DEVICE_CLASS_TEMPERATURE,
-                state_class=STATE_CLASS_MEASUREMENT,
-            ),
-            cv.Optional(CONF_PULSE_ACTUAL2): sensor.sensor_schema(
-                accuracy_decimals=2,
-                device_class=DEVICE_CLASS_TEMPERATURE,
-                state_class=STATE_CLASS_MEASUREMENT,
-            ),
-            cv.Optional(CONF_PULSE_SETPOINT1): sensor.sensor_schema(
-                accuracy_decimals=2,
-                device_class=DEVICE_CLASS_TEMPERATURE,
-                state_class=STATE_CLASS_MEASUREMENT,
-            ),
-            cv.Optional(CONF_PULSE_SETPOINT2): sensor.sensor_schema(
-                accuracy_decimals=2,
-                device_class=DEVICE_CLASS_TEMPERATURE,
-                state_class=STATE_CLASS_MEASUREMENT,
-            ),
+            cv.Optional(CONF_TEMPERATURE_PROBE1): _TEMPERATURE_PROBE_SCHEMA,
+            cv.Optional(CONF_TEMPERATURE_PROBE2): _TEMPERATURE_PROBE_SCHEMA,
+            cv.Optional(CONF_TEMPERATURE_PROBE3): _TEMPERATURE_PROBE_SCHEMA,
+            cv.Optional(CONF_TEMPERATURE_PROBE4): _TEMPERATURE_PROBE_SCHEMA,
+            cv.Optional(CONF_PULSE_ACTUAL1): _TEMPERATURE_PROBE_SCHEMA,
+            cv.Optional(CONF_PULSE_ACTUAL2): _TEMPERATURE_PROBE_SCHEMA,
+            cv.Optional(CONF_PULSE_SETPOINT1): _TEMPERATURE_PROBE_SCHEMA,
+            cv.Optional(CONF_PULSE_SETPOINT2): _TEMPERATURE_PROBE_SCHEMA,
             cv.Optional(CONF_PROPANE_LEVEL): sensor.sensor_schema(
                 unit_of_measurement=UNIT_PERCENT,
                 accuracy_decimals=0,

--- a/components/igrill_ble_listener/__init__.py
+++ b/components/igrill_ble_listener/__init__.py
@@ -1,22 +1,23 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import esp32_ble_tracker
-from esphome.const import CONF_ID
 
+AUTO_LOAD = ["esp32_ble_tracker"]
 DEPENDENCIES = ["esp32_ble_tracker"]
+CODEOWNERS = ["@bendikwa"]
 
 igrill_ble_listener_ns = cg.esphome_ns.namespace("igrill_ble_listener")
 IGrillBLEListener = igrill_ble_listener_ns.class_(
-    "IGrillBLEListener", esp32_ble_tracker.ESPBTDeviceListener
+    "IGrillBLEListener", esp32_ble_tracker.ESPBTDeviceListener, cg.Component
 )
 
 CONFIG_SCHEMA = cv.Schema(
-    {
-        cv.GenerateID(): cv.declare_id(IGrillBLEListener),
-    }
+    {cv.GenerateID(): cv.declare_id(IGrillBLEListener)}
 ).extend(esp32_ble_tracker.ESP_BLE_DEVICE_SCHEMA)
 
 
-def to_code(config):
-    var = cg.new_Pvariable(config[CONF_ID])
-    yield esp32_ble_tracker.register_ble_device(var, config)
+async def to_code(config):
+    var = cg.new_Pvariable(config[cv.CONF_ID])
+    await cg.register_component(var, config)
+    tracker = await cg.get_variable(config[esp32_ble_tracker.CONF_ESP32_BLE_ID])
+    cg.add(tracker.register_listener(var))

--- a/components/igrill_ble_listener/igrill_ble_listener.cpp
+++ b/components/igrill_ble_listener/igrill_ble_listener.cpp
@@ -1,43 +1,66 @@
 #include "igrill_ble_listener.h"
-#include "esphome/core/log.h"
 
 #ifdef USE_ESP32
 
 namespace esphome
 {
-    namespace igrill_ble_listener
+  namespace igrill_ble_listener
+  {
+
+    static const char *const TAG = "igrill_ble_listener";
+
+    // Known iGrill / Weber / iDevices service UUIDs used for device identification
+    static const std::string IGRILL_MINI_SERVICE    = "63c70000-4a82-4261-95ff-92cf32477861";
+    static const std::string IGRILL_MINIV2_SERVICE  = "9d610c43-ae1d-41a9-9b09-3c7ecd5c6035";
+    static const std::string IGRILLV2_SERVICE       = "a5c50000-f186-4bd6-97f2-7ebacba0d708";
+    static const std::string IGRILLV202_SERVICE     = "ada7590f-2e6d-469e-8f7b-1822b386a5e9";
+    static const std::string IGRILLV3_SERVICE       = "6e910000-58dc-41c7-943f-518b278cea88";
+    static const std::string IDEVICES_SERVICE       = "19450000-9b05-40bb-80d8-7c85840aec34";
+    static const std::string PULSE_1000_SERVICE     = "7e920000-68dc-41c7-943f-518b278cea87";
+    static const std::string PULSE_2000_SERVICE     = "7e920000-68dc-41c7-943f-518b278cea88";
+
+    bool IGrillBLEListener::parse_device(const esp32_ble_tracker::ESPBTDevice &device)
     {
+      for (auto &uuid : device.get_service_uuids())
+      {
+        char uuid_buf[37];
+        std::string uuid_str = uuid.to_str(uuid_buf);
+        // Lowercase for comparison
+        std::transform(uuid_str.begin(), uuid_str.end(), uuid_str.begin(), ::tolower);
 
-        static const char *const TAG = "igrill_ble_listener";
+        bool is_igrill = (
+          uuid_str == IGRILL_MINI_SERVICE   ||
+          uuid_str == IGRILL_MINIV2_SERVICE ||
+          uuid_str == IGRILLV2_SERVICE      ||
+          uuid_str == IGRILLV202_SERVICE    ||
+          uuid_str == IGRILLV3_SERVICE      ||
+          uuid_str == IDEVICES_SERVICE      ||
+          uuid_str == PULSE_1000_SERVICE    ||
+          uuid_str == PULSE_2000_SERVICE
+        );
 
-        bool IGrillBLEListener::parse_device(const esp32_ble_tracker::ESPBTDevice &device)
+        if (is_igrill)
         {
-
-            auto address_ = device.address();
-            if (address_[0] == 0x70 && address_[1] == 0x91 && address_[2] == 0x8F)
-            {
-                const uint64_t address = device.address_uint64();
-                for (auto &disc : this->already_discovered_)
-                {
-                    if (disc == address)
-                    {
-                        return true;
-                    }
-                }
-                this->already_discovered_.push_back(address);
-
-                ESP_LOGI(TAG, "Found IGrill device Name: %s (MAC: %s)", device.get_name().c_str(), device.address_str().c_str());
-                return true;
-            }
-            return false;
+          uint64_t address = device.address_uint64();
+          // Only log each device once per scan cycle
+          if (std::find(already_discovered_.begin(), already_discovered_.end(), address) == already_discovered_.end())
+          {
+            already_discovered_.push_back(address);
+            ESP_LOGI(TAG, "Found iGrill device, MAC address: %s  RSSI: %d dBm",
+                     device.address_str().c_str(), device.get_rssi());
+          }
+          return true;
         }
+      }
+      return false;
+    }
 
-        void IGrillBLEListener::on_scan_end()
-        {
-            this->already_discovered_.clear();
-        }
+    void IGrillBLEListener::on_scan_end()
+    {
+      already_discovered_.clear();
+    }
 
-    } // namespace igrill_ble_listener
+  } // namespace igrill_ble_listener
 } // namespace esphome
 
-#endif
+#endif // USE_ESP32

--- a/components/igrill_ble_listener/igrill_ble_listener.h
+++ b/components/igrill_ble_listener/igrill_ble_listener.h
@@ -1,24 +1,26 @@
 #pragma once
-
 #ifdef USE_ESP32
 
 #include "esphome/core/component.h"
+#include "esphome/core/helpers.h"
 #include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
 
 namespace esphome
 {
-    namespace igrill_ble_listener
+  namespace igrill_ble_listener
+  {
+    class IGrillBLEListener : public Component, public esp32_ble_tracker::ESPBTDeviceListener
     {
-
-        class IGrillBLEListener : public esp32_ble_tracker::ESPBTDeviceListener
-        {
-        protected:
-            bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
-            void on_scan_end() override;
-            std::vector<uint64_t> already_discovered_;
-        };
-
-    } // namespace igrill_ble_listener
+    public:
+      void setup() override {}
+      void dump_config() override {}
+      float get_setup_priority() const override { return setup_priority::DATA; }
+    protected:
+      bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
+      void on_scan_end() override;
+      std::vector<uint64_t> already_discovered_;
+    };
+  } // namespace igrill_ble_listener
 } // namespace esphome
 
-#endif
+#endif // USE_ESP32


### PR DESCRIPTION
## Fix ESPHome 2026.x compatibility

### Problem

This component fails to compile under ESPHome 2026.3.0+ with the following error:

```
src/esphome/components/igrill/igrill.cpp: In member function
'void esphome::igrill::IGrill::read_temperature_unit_(uint8_t*, uint16_t)':
src/esphome/components/igrill/igrill.cpp:294:19: error: 'class esphome::sensor::Sensor'
has no member named 'set_unit_of_measurement'; did you mean 'get_unit_of_measurement'?
  294 |           sensor->set_unit_of_measurement(this->unit_of_measurement_);
```

`Sensor::set_unit_of_measurement()` was removed from the ESPHome public API in 2026.x. Unit of measurement must now be declared at compile time via the sensor schema and cannot be changed at runtime.

Additionally, `ESPBTUUID::to_string()` is deprecated as of 2026.x (removed in 2026.8.0) in favour of `to_str(std::span<char, 37>)`.

### Changes

**`igrill.cpp`** — `read_temperature_unit_()`
- Removed the loop calling `sensor->set_unit_of_measurement()` on each probe sensor
- The device-reported unit (°C or °F) is now logged via `ESP_LOGI` for reference
- `request_read_values_()` is called directly as before
- Fixed missing `.c_str()` on `std::string` args passed to `ESP_LOGV` in `read_pulse_element_()`, which produces warnings on newer GCC/IDF toolchains

**`igrill.h`**
- Removed a stray `ESP_LOGE` debug statement left in the `set_send_value_when_unplugged()` inline method

**`sensor.py`**
- Temperature probe sensor schemas now specify `unit_of_measurement=UNIT_CELSIUS` as the compile-time default, matching the iGrill device default
- Users whose device is configured for Fahrenheit can override per-probe in YAML:
  ```yaml
  temperature_probe1:
    name: "Probe 1"
    unit_of_measurement: "°F"
  ```

**`igrill_ble_listener/__init__.py`**
- Updated BLE listener registration to work with ESPHome 2026.x
- `register_listener()` is now called on the `ESP32BLETracker` instance directly rather than via `App`
- Extended schema with `ESP_BLE_DEVICE_SCHEMA` so the tracker ID is correctly resolved at code generation time
- Added `await` to async registration calls

**`igrill_ble_listener/igrill_ble_listener.cpp`**
- Replaced deprecated `ESPBTUUID::to_string()` with the new `to_str(char buf[37])` signature

**`igrill_ble_listener/igrill_ble_listener.h`**
- Added `Component` as a base class alongside `ESPBTDeviceListener` as required by 2026.x component registration
- Added `setup()`, `dump_config()`, and `get_setup_priority()` overrides accordingly

### Behaviour impact

Previously the component auto-applied the unit reported by the device over BLE on first connect. That unit is still read from the device and logged — it just can no longer be applied at runtime. Users with iGrills configured for Fahrenheit will need to add `unit_of_measurement: "°F"` to each probe in their YAML. The default compile-time unit is `°C`, which matches the iGrill device default and the previous behaviour for the majority of users.

### Tested against

- ESPHome 2026.3.0
- esp-idf 5.5.3 (framework-espidf 3.50503.0)
- ESP32 (`esp32dev` board) with `bluetooth_proxy` + `ble_client`
- Compiled and flashed successfully; iGrill device not available for runtime validation at time of PR