### PR TITLE
Log warning on configuration missmatch

### DIFF
--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -306,7 +306,7 @@ namespace esphome
       {
         if (this->sensors_[i])
         {
-          const StringRef unit = this->sensors_[i]->get_unit_of_measurement_ref() if (unit.compare(this->unit_of_measurement_))
+          const StringRef unit = this->sensors_[i]->get_unit_of_measurement_ref() if (unit.compare(this->unit_of_measurement_));
           {
             ESP_LOGI(TAG, "Temperature unit configured for %s in YAML: %s", this->sensors_[i]->get_name(), this->sensors_[i]->get_unit_of_measurement_ref());
           }

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -300,6 +300,8 @@ namespace esphome
       // The device-reported unit is logged here for reference only.
       // If your iGrill is set to °F, add `unit_of_measurement: "°F"` to each probe in YAML.
       ESP_LOGI(TAG, "Device reports temperature unit: %s (unit set at compile time via YAML, not at runtime)", this->unit_of_measurement_);
+      ESP_LOGI(TAG, "Temperature unit configured in YAML: %s", this->get_unit_of_measurement_ref());
+
       request_read_values_();
     }
 

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -300,8 +300,13 @@ namespace esphome
       // The device-reported unit is logged here for reference only.
       // If your iGrill is set to °F, add `unit_of_measurement: "°F"` to each probe in YAML.
       ESP_LOGI(TAG, "Device reports temperature unit: %s (unit set at compile time via YAML, not at runtime)", this->unit_of_measurement_);
-      ESP_LOGI(TAG, "Temperature unit configured in YAML: %s", this->get_unit_of_measurement_ref());
-
+      for (int i = 0; i < this->num_probes; i++)
+      {
+        if (this->sensors_[i]) // only add handles for configured sensors
+        {
+          ESP_LOGI(TAG, "Temperature unit configured in YAML: %s", this->sensors_[i]->get_unit_of_measurement_ref());
+        }
+      }
       request_read_values_();
     }
 

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -307,6 +307,7 @@ namespace esphome
         if (this->sensors_[i])
         {
           const StringRef unit = this->sensors_[i]->get_unit_of_measurement_ref();
+          if (unit.compare(this->unit_of_measurement_))
           {
             ESP_LOGI(TAG, "Temperature unit configured for %s in YAML: %s", this->sensors_[i]->get_name(), this->sensors_[i]->get_unit_of_measurement_ref());
           }

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -258,7 +258,7 @@ namespace esphome
       if (this->pulse_heating_actual1_)
       {
         std::string actual1;
-        actual1.assign(reinterpret_cast<char *>(raw_value)+1, 3);
+        actual1.assign(reinterpret_cast<char*>(raw_value)+1, 3);
         ESP_LOGV(TAG, "Parsed actual1 from pulse element data %s", actual1.c_str());
         this->pulse_heating_actual1_->publish_state(stoi(actual1));
       }
@@ -272,14 +272,14 @@ namespace esphome
       if (this->pulse_heating_setpoint1_)
       {
         std::string setpoint1;
-        setpoint1.assign(reinterpret_cast<char *>(raw_value)+9, 3);
+        setpoint1.assign(reinterpret_cast<char*>(raw_value)+9, 3);
         ESP_LOGV(TAG, "Parsed setpoint1 from pulse element data %s", setpoint1.c_str());
         this->pulse_heating_setpoint1_->publish_state(stoi(setpoint1));
       }
       if (this->pulse_heating_setpoint2_)
       {
         std::string setpoint2;
-        setpoint2.assign(reinterpret_cast<char *>(raw_value)+13, 3);
+        setpoint2.assign(reinterpret_cast<char*>(raw_value)+13, 3);
         ESP_LOGV(TAG, "Parsed setpoint2 from pulse element data %s", setpoint2.c_str());
         this->pulse_heating_setpoint2_->publish_state(stoi(setpoint2));
       }

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -300,20 +300,18 @@ namespace esphome
       // The device-reported unit is logged here for reference only.
       // If your iGrill is set to °F, add `unit_of_measurement: "°F"` to each probe in YAML.
       ESP_LOGI(TAG, "Device reports temperature unit: %s (unit set at compile time via YAML, not at runtime)", this->unit_of_measurement_);
-
-      // Checks configured unit of measurement for all configured sensors, and logs a warning if they do not match the device
       for (int i = 0; i < this->num_probes; i++)
       {
         if (this->sensors_[i])
         {
-          const StringRef unit = this->sensors_[i]->get_unit_of_measurement_ref();
-          if (unit.compare(this->unit_of_measurement_))
+          if (this->unit_of_measurement_ == this->sensors_[i]->get_unit_of_measurement_ref())
           {
-            ESP_LOGI(TAG, "Temperature unit configured for %s in YAML: %s", this->sensors_[i]->get_name(), this->sensors_[i]->get_unit_of_measurement_ref());
+            ESP_LOGD(TAG, "Sensor: %s match unit set in YAML: %s", this->sensors_[i]->get_name().c_str(), this->sensors_[i]->get_unit_of_measurement_ref().c_str());
           }
           else
           {
-            ESP_LOGW(TAG, "Missmatch in temperature unit. Device reports %s, while %s is configured as %s in YAML.", this->unit_of_measurement_, this->sensors_[i]->get_name(), this->sensors_[i]->get_unit_of_measurement_ref());
+            ESP_LOGW(TAG, "Sensor: %s unit set in YAML: %s does not match device-reported unit: %s. Please update your YAML to set the correct unit_of_measurement for this sensor or change the device unit with the iGrill app.",
+                     this->sensors_[i]->get_name().c_str(), this->sensors_[i]->get_unit_of_measurement_ref().c_str(), this->unit_of_measurement_);
           }
         }
       }

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -265,7 +265,7 @@ namespace esphome
       if (this->pulse_heating_actual2_)
       {
         std::string actual2;
-        actual2.assign(reinterpret_cast<char *>(raw_value)+5, 3);
+        actual2.assign(reinterpret_cast<char*>(raw_value)+5, 3);
         ESP_LOGV(TAG, "Parsed actual2 from pulse element data %s", actual2.c_str());
         this->pulse_heating_actual2_->publish_state(stoi(actual2));
       }

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -306,7 +306,7 @@ namespace esphome
       {
         if (this->sensors_[i])
         {
-          const StringRef unit = this->sensors_[i]->get_unit_of_measurement_ref() if (unit.compare(this->unit_of_measurement_));
+          const StringRef unit = this->sensors_[i]->get_unit_of_measurement_ref();
           {
             ESP_LOGI(TAG, "Temperature unit configured for %s in YAML: %s", this->sensors_[i]->get_name(), this->sensors_[i]->get_unit_of_measurement_ref());
           }

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -218,7 +218,7 @@ namespace esphome
         }
         else
         {
-          ESP_LOGD(TAG, "No sensor configured for probe number %d. Skipping", i+1);
+          ESP_LOGD(TAG, "No sensor configured for probe number %d. Skipping", i + 1);
         }
       }
       if (service == PULSE_1000_TEMPERATURE_SERVICE_UUID || service == PULSE_2000_TEMPERATURE_SERVICE_UUID)
@@ -258,28 +258,28 @@ namespace esphome
       if (this->pulse_heating_actual1_)
       {
         std::string actual1;
-        actual1.assign(reinterpret_cast<char*>(raw_value)+1, 3);
+        actual1.assign(reinterpret_cast<char *>(raw_value) + 1, 3);
         ESP_LOGV(TAG, "Parsed actual1 from pulse element data %s", actual1.c_str());
         this->pulse_heating_actual1_->publish_state(stoi(actual1));
       }
       if (this->pulse_heating_actual2_)
       {
         std::string actual2;
-        actual2.assign(reinterpret_cast<char*>(raw_value)+5, 3);
+        actual2.assign(reinterpret_cast<char *>(raw_value) + 5, 3);
         ESP_LOGV(TAG, "Parsed actual2 from pulse element data %s", actual2.c_str());
         this->pulse_heating_actual2_->publish_state(stoi(actual2));
       }
       if (this->pulse_heating_setpoint1_)
       {
         std::string setpoint1;
-        setpoint1.assign(reinterpret_cast<char*>(raw_value)+9, 3);
+        setpoint1.assign(reinterpret_cast<char *>(raw_value) + 9, 3);
         ESP_LOGV(TAG, "Parsed setpoint1 from pulse element data %s", setpoint1.c_str());
         this->pulse_heating_setpoint1_->publish_state(stoi(setpoint1));
       }
       if (this->pulse_heating_setpoint2_)
       {
         std::string setpoint2;
-        setpoint2.assign(reinterpret_cast<char*>(raw_value)+13, 3);
+        setpoint2.assign(reinterpret_cast<char *>(raw_value) + 13, 3);
         ESP_LOGV(TAG, "Parsed setpoint2 from pulse element data %s", setpoint2.c_str());
         this->pulse_heating_setpoint2_->publish_state(stoi(setpoint2));
       }
@@ -300,11 +300,20 @@ namespace esphome
       // The device-reported unit is logged here for reference only.
       // If your iGrill is set to °F, add `unit_of_measurement: "°F"` to each probe in YAML.
       ESP_LOGI(TAG, "Device reports temperature unit: %s (unit set at compile time via YAML, not at runtime)", this->unit_of_measurement_);
+
+      // Checks configured unit of measurement for all configured sensors, and logs a warning if they do not match the device
       for (int i = 0; i < this->num_probes; i++)
       {
-        if (this->sensors_[i]) // only add handles for configured sensors
+        if (this->sensors_[i])
         {
-          ESP_LOGI(TAG, "Temperature unit configured in YAML: %s", this->sensors_[i]->get_unit_of_measurement_ref());
+          const StringRef unit = this->sensors_[i]->get_unit_of_measurement_ref() if (unit.compare(this->unit_of_measurement_))
+          {
+            ESP_LOGI(TAG, "Temperature unit configured for %s in YAML: %s", this->sensors_[i]->get_name(), this->sensors_[i]->get_unit_of_measurement_ref());
+          }
+          else
+          {
+            ESP_LOGW(TAG, "Missmatch in temperature unit. Device reports %s, while %s is configured as %s in YAML.", this->unit_of_measurement_, this->sensors_[i]->get_name(), this->sensors_[i]->get_unit_of_measurement_ref());
+          }
         }
       }
       request_read_values_();

--- a/components/igrill/igrill.cpp
+++ b/components/igrill/igrill.cpp
@@ -218,7 +218,7 @@ namespace esphome
         }
         else
         {
-          ESP_LOGD(TAG, "No sensor configured for probe number %d. Skipping", i + 1);
+          ESP_LOGD(TAG, "No sensor configured for probe number %d. Skipping", i+1);
         }
       }
       if (service == PULSE_1000_TEMPERATURE_SERVICE_UUID || service == PULSE_2000_TEMPERATURE_SERVICE_UUID)
@@ -258,28 +258,28 @@ namespace esphome
       if (this->pulse_heating_actual1_)
       {
         std::string actual1;
-        actual1.assign(reinterpret_cast<char *>(raw_value) + 1, 3);
+        actual1.assign(reinterpret_cast<char *>(raw_value)+1, 3);
         ESP_LOGV(TAG, "Parsed actual1 from pulse element data %s", actual1.c_str());
         this->pulse_heating_actual1_->publish_state(stoi(actual1));
       }
       if (this->pulse_heating_actual2_)
       {
         std::string actual2;
-        actual2.assign(reinterpret_cast<char *>(raw_value) + 5, 3);
+        actual2.assign(reinterpret_cast<char *>(raw_value)+5, 3);
         ESP_LOGV(TAG, "Parsed actual2 from pulse element data %s", actual2.c_str());
         this->pulse_heating_actual2_->publish_state(stoi(actual2));
       }
       if (this->pulse_heating_setpoint1_)
       {
         std::string setpoint1;
-        setpoint1.assign(reinterpret_cast<char *>(raw_value) + 9, 3);
+        setpoint1.assign(reinterpret_cast<char *>(raw_value)+9, 3);
         ESP_LOGV(TAG, "Parsed setpoint1 from pulse element data %s", setpoint1.c_str());
         this->pulse_heating_setpoint1_->publish_state(stoi(setpoint1));
       }
       if (this->pulse_heating_setpoint2_)
       {
         std::string setpoint2;
-        setpoint2.assign(reinterpret_cast<char *>(raw_value) + 13, 3);
+        setpoint2.assign(reinterpret_cast<char *>(raw_value)+13, 3);
         ESP_LOGV(TAG, "Parsed setpoint2 from pulse element data %s", setpoint2.c_str());
         this->pulse_heating_setpoint2_->publish_state(stoi(setpoint2));
       }


### PR DESCRIPTION
Warns if YAML configured `unit_of_measurement` does not match unit read from device.